### PR TITLE
Upgrade to Version 1.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,13 @@
 # Do not control any user-level IDE configuration files
-GtfsServer.pro.user
+GtfsProcSuite.pro.user
 
 # Do not control any QMake local configs
 .qmake.stash
 
 # Temporary editor files
 *~
+
+# GTFS Real-Time Protoc'd Files
+gtfs_realtime/gtfs-realtime.pb.cc
+gtfs_realtime/gtfs-realtime.pb.h
+

--- a/GtfsProc_Documentation.html
+++ b/GtfsProc_Documentation.html
@@ -705,7 +705,7 @@ Reinitialize the display with 'HOM', quit using 'BYE' <br>
     </tr>
     <tr>
         <td class="fixed">
-            uptm_ms
+            uptm_s
         </td>
         <td class="fixed">
             integer

--- a/GtfsProc_Documentation.html
+++ b/GtfsProc_Documentation.html
@@ -2,7 +2,7 @@
 <head>
 </head>
     <meta charset="UTF-8">
-    <title>GtfsProc Server and Transaction Documentation (Version 1.7d)</title>
+    <title>GtfsProc Server and Transaction Documentation (Version 1.8)</title>
     <style>
         .fixed {
             font-family: monospace;
@@ -36,7 +36,7 @@
     GtfsProc was written almost entirely in the Qt Application Framework. The TCP server code comes from Bryan Cairns of VoidRealms. See http://www.voidrealms.com/ for the original source and license. The GtfsProc code is written by Daniel Brook (danb358 {AT} gmail {DOT} com), (c) 2018-2020, GPL v 3.
 </p>
 <p>
-    This is the documentation for <b>GtfsProc Version 1.7d (31-May-2020)</b>
+    This is the documentation for <b>GtfsProc Version 1.8 (18-Oct-2020)</b>
 </p>
 
 <h1>Server Options</h1>
@@ -48,7 +48,7 @@
     <li><b class="fixed">-h, --help</b>: Displays all command line options.</li>
     <li><b class="fixed">-d {path to feed}</b>: File system location of the static feed (where stoptimes.txt, routes.txt, etc. are found).</li>
     <li><b class="fixed">-p {port number}</b>: TCP port to open for client connections (defaults to 5000 if not specified).</li>
-    <li><b class="fixed">-t {number of threads}</b>: Specify the number of threads to dedicate to GTFSProc (this will equal the number of simultaneously-processed transactions, defaults to 1).</li>
+    <li><b class="fixed">-t {number of threads}</b>: Specify the number of threads to dedicate to GtfsProc (this will equal the number of simultaneously-processed transactions, defaults to 1).</li>
     <li><b class="fixed">-r {URL or file path}</b>: URL or local file path of the protocol buffer GTFS-Realtime file (optional).</li>
     <li><b class="fixed">-u {number of seconds}</b>: Specify the number of seconds between each attempt to refresh GTFS-Realtime data (defaults to 120 seconds).</li>
     <li><b class="fixed">-a</b>: Shows all times using a 12-hour format with AM/PM indicators (the default display is with 24-hour clocks).</li>
@@ -179,7 +179,7 @@ Reinitialize the display with 'HOM', quit using 'BYE' <br>
 
 <h1>Modules</h1>
 <p>
-    There are 18 modules available for integrating schedule/stop information and retrieving them over a TCP socket. All responses from GTFSProc are encoded in JSON (JavaScript Object Notation) an terminated with a newline ‘\n’ character.
+    There are 18 modules available for integrating schedule/stop information and retrieving them over a TCP socket. All responses from GtfsProc are encoded in JSON (JavaScript Object Notation) an terminated with a newline ‘\n’ character.
 </p>
 
 <h2>Standard Response Parameters</h2>
@@ -196,7 +196,7 @@ Reinitialize the display with 'HOM', quit using 'BYE' <br>
     These above two conditions should be checked against. Successful responses will always have an error code of 0 along with the 3-letter code of the module you requested. All other error codes are module-specific.
 </p>
 <p>
-    All GTFSProc modules have the following parameters in addition to the module-specific responses:
+    All GtfsProc modules have the following parameters in addition to the module-specific responses:
 </p>
 <table class="fieldDocumentation">
     <tr>
@@ -277,13 +277,13 @@ Reinitialize the display with 'HOM', quit using 'BYE' <br>
     </tr>
     <tr>
         <td class="fixed">
-            appuptime_ms
+            appuptime_sec
         </td>
         <td class="fixed">
             integer
         </td>
         <td>
-            Number of milliseconds the processor has been running.
+            Number of seconds the processor has been running.
         </td>
     </tr>
     <tr>
@@ -485,7 +485,7 @@ Reinitialize the display with 'HOM', quit using 'BYE' <br>
 
 <h2>Real-Time Data Buffer Status (RDS)</h2>
 <p>
-    This module provides information about the real-time prediction data used for producing the wait times of GTFSProc.
+    This module provides information about the real-time prediction data used for producing the wait times of GtfsProc.
 </p>
 <h4>Request Format</h4>
 <p>RDS</p>
@@ -598,7 +598,7 @@ Reinitialize the display with 'HOM', quit using 'BYE' <br>
 <p>RTI</p>
 <h4>Response Format</h4>
 <p>
-    This is purely for debugging / saving information for bug-reporting purposes and not for general consumption, so the response details will not be enumerated here. See the GTFS-Realtime specification for details about the feed format. This is the only GTFSProc module which does not obey the standard response fields.
+    This is purely for debugging / saving information for bug-reporting purposes and not for general consumption, so the response details will not be enumerated here. See the GTFS-Realtime specification for details about the feed format. This is the only GtfsProc module which does not obey the standard response fields.
 </p>
 <table class="fieldDocumentation">
     <tr>
@@ -996,7 +996,7 @@ Reinitialize the display with 'HOM', quit using 'BYE' <br>
             agency_id
         </td>
         <td class="fixed">
-            integer
+            string
         </td>
         <td>
             Agency to which a Route ID belongs
@@ -2669,7 +2669,7 @@ Fields in gray shadow are only available in TRI requests, fields in orange shado
 
 <h2>Upcoming / Next Service for Stop ID(s)</h2>
 <p>
-    The primary purpose of GTFSProc was envisioned for this purpose: displaying the wait time for upcoming service at a particular stop, list of stops, or parent station. The NEX/NCF modules accomplish this by loading all relevant trips* for the number of future minutes requested. If real-time data is relevant on the server, then the scheduled trips operating, added service, and canceled trip IDs are all merged and then for all trips who have no departed a stop or have not yet arrived will be sorted by the wait time to get to the station (if no arrival time is available, we look at the departure time for the countdown).
+    The primary purpose of GtfsProc was envisioned for this purpose: displaying the wait time for upcoming service at a particular stop, list of stops, or parent station. The NEX/NCF modules accomplish this by loading all relevant trips* for the number of future minutes requested. If real-time data is relevant on the server, then the scheduled trips operating, added service, and canceled trip IDs are all merged and then for all trips who have no departed a stop or have not yet arrived will be sorted by the wait time to get to the station (if no arrival time is available, we look at the departure time for the countdown).
 </p>
 <p>
     * a “relevant” trip could come from a previous service day (when trips operate: a) after midnight on a previous service date render on the current date, b) the current date (naturally), and c) the next date (since the look-ahead time might have to pull trips from tomorrow’s service date).

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,6 +1,6 @@
 THIS RELEASE: Version 1.8 Features and Fixes:
 ---------------------------------------------
-- Use seconds instead of milliseconds for uptime display in SDS
+- Use seconds instead of milliseconds for uptime display in SDS and RPS
 - Fix agency_id to be a string in the RTE response (was previously a int by mistake)
 
 PREVIOUS RELEASES:

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,5 +1,11 @@
-THIS RELEASE: Version 1.7 Features and Fixes:
+THIS RELEASE: Version 1.8 Features and Fixes:
 ---------------------------------------------
+- Use seconds instead of milliseconds for uptime display in SDS
+- Fix agency_id to be a string in the RTE response (was previously a int by mistake)
+
+PREVIOUS RELEASES:
+Version 1.7 Features/Fixes
+--------------------------
 This is a major bugfix/feature release specifically focused at GTFS-Realtime processing
  - New RPS module - allows for monitoring of the status of integrated real-time trip updates from a
    transit agency, including such parameters as:
@@ -27,9 +33,6 @@ This is a major bugfix/feature release specifically focused at GTFS-Realtime pro
    Previously, checks of the Stop Sequence were done without verifying the Stop ID matched the real-time
    trip updates and static schedule, so trips showed with all sorts of crazy predictions. By using -q, we
    perform matching of real-time trip updates ONLY by Stop ID, even though a Stop Sequence is present.
-
-
-PREVIOUS RELEASES:
 
 Version 1.6 Features and Fixes:
 -------------------------------

--- a/gtfs_modules/realtimeproductstatus.cpp
+++ b/gtfs_modules/realtimeproductstatus.cpp
@@ -39,7 +39,7 @@ RealtimeProductStatus::RealtimeProductStatus() : StaticStatus(), _rg(GTFS::RealT
 
 void RealtimeProductStatus::fillResponseData(QJsonObject &resp)
 {
-    resp["uptm_ms"] = _stat->getServerStartTimeUTC().msecsTo(QDateTime::currentDateTimeUtc());
+    resp["uptm_s"]  = _stat->getServerStartTimeUTC().secsTo(QDateTime::currentDateTimeUtc());
     resp["statdat"] = _stat->getStaticDatasetModifiedTime().toString("dd-MMM-yyyy hh:mm:ss t");
     resp["nb_reqs"] = GTFS::DataGateway::inst().getHandledRequests();
 

--- a/gtfs_modules/staticstatus.cpp
+++ b/gtfs_modules/staticstatus.cpp
@@ -80,7 +80,7 @@ void StaticStatus::fillResponseData(QJsonObject &resp)
 
     resp["application"]      = appName.remove("\"") + " " + appVers.remove("\"");
     resp["records"]          = _stat->getRecordsLoaded();
-    resp["appuptime_ms"]     = _stat->getServerStartTimeUTC().msecsTo(_currUTC);
+    resp["appuptime_sec"]    = _stat->getServerStartTimeUTC().secsTo(_currUTC);
     resp["dataloadtime_ms"]  = _stat->getServerStartTimeUTC().msecsTo(_stat->getLoadFinishTimeUTC());
     resp["threadpool_count"] = QThreadPool::globalInstance()->maxThreadCount();
     resp["processed_reqs"]   = GTFS::DataGateway::inst().getHandledRequests();

--- a/gtfs_process/gtfsroute.cpp
+++ b/gtfs_process/gtfsroute.cpp
@@ -43,7 +43,7 @@ Routes::Routes(const QString dataRootPath, QObject *parent) : QObject(parent)
     // to be safe we just check them all against the default/not-found value of -1
     for (int l = 1; l < dataStore.size(); ++l) {
         RouteRec route;
-        route.agency_id        = (agencyIdPos  != -1) ? dataStore.at(l).at(agencyIdPos).toInt() : 0;  // 0-by-default?
+        route.agency_id        = (agencyIdPos  != -1) ? dataStore.at(l).at(agencyIdPos) : "";
         route.route_short_name = (shortNamePos != -1) ? dataStore.at(l).at(shortNamePos) : "";
         route.route_long_name  = (longNamePos  != -1) ? dataStore.at(l).at(longNamePos) : "";
         route.route_desc       = (descPos      != -1) ? dataStore.at(l).at(descPos) : "";

--- a/gtfs_process/gtfsroute.h
+++ b/gtfs_process/gtfsroute.h
@@ -32,7 +32,7 @@ namespace GTFS {
 // To save space we only use the required subset of route records
 typedef struct {
 //  QString  route_id;          // Primary Key, we don't need to define this here
-    qint32   agency_id;
+    QString  agency_id;
     QString  route_short_name;
     QString  route_long_name;
     QString  route_desc;

--- a/gtfsproc/server_main.cpp
+++ b/gtfsproc/server_main.cpp
@@ -33,7 +33,7 @@ int main(int argc, char *argv[])
      */
     QCoreApplication a(argc, argv);
     QCoreApplication::setApplicationName("GtfsProc");
-    QCoreApplication::setApplicationVersion("1.7d");
+    QCoreApplication::setApplicationVersion("1.8");
 
     QTextStream console(stdout);
     QString appName = QCoreApplication::applicationName();


### PR DESCRIPTION
Use seconds instead of milliseconds for uptime display in SDS and RPS
Fix agency_id to be a string in the RTE response (was previously a int by mistake)