### PR TITLE
Remove too-restrictive StopID and Sequence Matching of Real-Time Updates

### DIFF
--- a/GtfsProc_Documentation.html
+++ b/GtfsProc_Documentation.html
@@ -2,7 +2,7 @@
 <head>
 </head>
     <meta charset="UTF-8">
-    <title>GtfsProc Server and Transaction Documentation (Version 1.8)</title>
+    <title>GtfsProc Server and Transaction Documentation (Version 1.8a)</title>
     <style>
         .fixed {
             font-family: monospace;
@@ -36,7 +36,7 @@
     GtfsProc was written almost entirely in the Qt Application Framework. The TCP server code comes from Bryan Cairns of VoidRealms. See http://www.voidrealms.com/ for the original source and license. The GtfsProc code is written by Daniel Brook (danb358 {AT} gmail {DOT} com), (c) 2018-2020, GPL v 3.
 </p>
 <p>
-    This is the documentation for <b>GtfsProc Version 1.8 (18-Oct-2020)</b>
+    This is the documentation for <b>GtfsProc Version 1.8a (27-Oct-2020)</b>
 </p>
 
 <h1>Server Options</h1>
@@ -78,7 +78,7 @@
     </li>
 </ol>
 <div class="fixed">
-GtfsProc version 1.7d - Running on Process ID: 22112<br>
+GtfsProc version 1.8a - Running on Process ID: 22112<br>
 <br>
 Starting Feed Information Gathering ... <br>
 Starting Agency Gathering ...<br>

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,9 +1,16 @@
-THIS RELEASE: Version 1.8 Features and Fixes:
----------------------------------------------
+THIS RELEASE: Version 1.8a Features and Fixes:
+----------------------------------------------
+- Do not force check of stop ID for real-time integration if the -q option is not used, the sequence match
+  is sufficient per the specification (ex: Trip departing South Station (MBTA) gets a sub-station 'track'
+  assigned: 'South-Station-02' instead of 'South Station' but it retains stop sequence 1).
+
+
+PREVIOUS RELEASES:
+Version 1.8 Features/Fixes
+--------------------------
 - Use seconds instead of milliseconds for uptime display in SDS and RPS
 - Fix agency_id to be a string in the RTE response (was previously a int by mistake)
 
-PREVIOUS RELEASES:
 Version 1.7 Features/Fixes
 --------------------------
 This is a major bugfix/feature release specifically focused at GTFS-Realtime processing

--- a/gtfs_realtime/gtfsrealtimefeed.cpp
+++ b/gtfs_realtime/gtfsrealtimefeed.cpp
@@ -338,8 +338,7 @@ void RealTimeTripUpdate::tripStopActualTime(const QString              &tripID,
         // (for quality assurance, these kinds of trips will still be considered mimatches as they violate spec)
         QString stopIdRT = QString::fromStdString(tri.stop_time_update(rtSTUpd).stop_id());
         if (tri.stop_time_update(rtSTUpd).has_stop_sequence() &&
-            stopSeq == tri.stop_time_update(rtSTUpd).stop_sequence() &&
-            stop_id == stopIdRT) {
+            stopSeq == tri.stop_time_update(rtSTUpd).stop_sequence()) {
             // Match Stop ID and Stop Sequence when both are provided
             break;
         } else if ((!tri.stop_time_update(rtSTUpd).has_stop_sequence() || _loosenStopSeqEnf) && stop_id == stopIdRT) {
@@ -460,8 +459,7 @@ void RealTimeTripUpdate::fillStopTimesForTrip(rtUpdateMatch               realTi
                 // (should also enforce that the stop id matches the trip update contents)
                 QString stopIdRT = QString::fromStdString(tri.stop_time_update(stUpdIdx).stop_id());
                 if (tri.stop_time_update(stUpdIdx).has_stop_sequence() &&
-                    stopRec.stop_sequence == tri.stop_time_update(stUpdIdx).stop_sequence() &&
-                    stopRec.stop_id == stopIdRT) {
+                    stopRec.stop_sequence == tri.stop_time_update(stUpdIdx).stop_sequence()) {
                     stu.stopSequence = stopRec.stop_sequence;
                     break;
                 } else if ((!tri.stop_time_update(stUpdIdx).has_stop_sequence() || _loosenStopSeqEnf) &&


### PR DESCRIPTION
The GTFS-Realtime specification states that stop sequences are sufficient to match a trip update with the schedule, so I've removed the deliberate check for BOTH stop IDs and sequences if -q was not requested.