### PR TITLE
Version 1.8b

### DIFF
--- a/GtfsProc_Documentation.html
+++ b/GtfsProc_Documentation.html
@@ -2,7 +2,7 @@
 <head>
 </head>
     <meta charset="UTF-8">
-    <title>GtfsProc Server and Transaction Documentation (Version 1.8a)</title>
+    <title>GtfsProc Server and Transaction Documentation (Version 1.8b)</title>
     <style>
         .fixed {
             font-family: monospace;
@@ -33,10 +33,10 @@
     Thank you for trying GtfsProc! This is a GTFS data processor to present stop, route, service, and schedule lookups, but its principal purpose is to provide wait time estimations for stops in a transit system, integrating GTFS-Realtime data where available. All data processing is done on a server process in response to client queries over a TCP connection. This allows the process to work over network connections or on local machines.
 </p>
 <p>
-    GtfsProc was written almost entirely in the Qt Application Framework. The TCP server code comes from Bryan Cairns of VoidRealms. See http://www.voidrealms.com/ for the original source and license. The GtfsProc code is written by Daniel Brook (danb358 {AT} gmail {DOT} com), (c) 2018-2020, GPL v 3.
+    GtfsProc was written almost entirely in the Qt Application Framework. The TCP server code comes from Bryan Cairns of VoidRealms. See http://www.voidrealms.com/ for the original source and license. The GtfsProc code is written by Daniel Brook (danb358 {AT} gmail {DOT} com), (c) 2018-2021, GPL v 3.
 </p>
 <p>
-    This is the documentation for <b>GtfsProc Version 1.8a (27-Oct-2020)</b>
+    This is the documentation for <b>GtfsProc Version 1.8b (25-Feb-2021)</b>
 </p>
 
 <h1>Server Options</h1>
@@ -78,7 +78,7 @@
     </li>
 </ol>
 <div class="fixed">
-GtfsProc version 1.8a - Running on Process ID: 22112<br>
+GtfsProc version 1.8b - Running on Process ID: 22112<br>
 <br>
 Starting Feed Information Gathering ... <br>
 Starting Agency Gathering ...<br>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See the GtfsProc_Documentation.html file for details on starting the server and 
 the schema for all the responses to different request types.
 
 The TCP server code comes from Bryan Cairns of VoidRealms. See http://www.voidrealms.com/ for the original source and license.
-The GtfsProc code is written by Daniel Brook, (c) 2018-2020, GPLv3.
+The GtfsProc code is written by Daniel Brook, (c) 2018-2021, GPLv3.
 
 GtfsProcSuite consists of 3 applications:
 - Server that loads the schedule data (and real-time data if available) and processes client requests (gtfsproc/)

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,11 +1,20 @@
-THIS RELEASE: Version 1.8a Features and Fixes:
+THIS RELEASE: Version 1.8b Features and Fixes:
 ----------------------------------------------
+- Update copyright dates
+- Added non-regression test suite
+- Canceled trips should not return garbage numbers for schedule offset
+- Fixed deprecated feature use (as asserted by Qt 5.15)
+- Cleanup some dead code
+- Actually increment version number this time
+
+
+PREVIOUS RELEASES:
+Version 1.8a Features and Fixes
+-------------------------------
 - Do not force check of stop ID for real-time integration if the -q option is not used, the sequence match
   is sufficient per the specification (ex: Trip departing South Station (MBTA) gets a sub-station 'track'
   assigned: 'South-Station-02' instead of 'South Station' but it retains stop sequence 1).
 
-
-PREVIOUS RELEASES:
 Version 1.8 Features/Fixes
 --------------------------
 - Use seconds instead of milliseconds for uptime display in SDS and RPS

--- a/client_cli/client_main.cpp
+++ b/client_cli/client_main.cpp
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/client_cli/clientgtfs.cpp
+++ b/client_cli/clientgtfs.cpp
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *
@@ -41,10 +41,6 @@ bool ClientGtfs::startConnection(QString hostname, quint16 port, int userTimeout
         this->disp.showError(this->commSocket.errorString());
         return false;
     }
-
-
-    // Now that we are connected, show the server connected message (ehh ... there's no good point to do this)
-//    disp.showServer(hostname, port);
 
     return true;
 }
@@ -182,7 +178,7 @@ void ClientGtfs::repl()
             screen << "GTFS Server Status"
                    << qSetFieldWidth(this->disp.getCols() - 18)      // 18 == "GTFS Server Status".length()
                    << respObj["message_time"].toString()
-                   << qSetFieldWidth(0) << endl << endl;
+                   << qSetFieldWidth(0) << Qt::endl << Qt::endl;
 
             // Easier to understand uptime
             qint64 uptimeMs = respObj["appuptime_ms"].toInt();
@@ -191,33 +187,33 @@ void ClientGtfs::repl()
             qint8  mins     = (uptimeMs - days * 86400000 - hours * 3600000) / 60000;
             qint8  secs     = (uptimeMs - days * 86400000 - hours * 3600000 - mins * 60000) / 1000;
 
-            screen << "[ Backend ]" << endl;
-            screen << "Processed Reqs . . " << respObj["processed_reqs"].toInt() << endl;
+            screen << "[ Backend ]" << Qt::endl;
+            screen << "Processed Reqs . . " << respObj["processed_reqs"].toInt() << Qt::endl;
             screen << "Uptime . . . . . . " << days  << "d " << qSetFieldWidth(2)
                                             << hours << "h "
                                             << mins  << "m "
-                                            << secs  << "s " << qSetFieldWidth(0) << endl;
-            screen << "Data Load Time . . " << respObj["dataloadtime_ms"].toInt() << "ms" << endl;
-            screen << "Thread Pool  . . . " << respObj["threadpool_count"].toInt() << endl;
-            screen << "System Version . . " << respObj["application"].toString() << endl << endl;
+                                            << secs  << "s " << qSetFieldWidth(0) << Qt::endl;
+            screen << "Data Load Time . . " << respObj["dataloadtime_ms"].toInt() << "ms" << Qt::endl;
+            screen << "Thread Pool  . . . " << respObj["threadpool_count"].toInt() << Qt::endl;
+            screen << "System Version . . " << respObj["application"].toString() << Qt::endl << Qt::endl;
 
-            screen << "[ Static Feed Information ]" << endl;
-            screen << "Publisher  . . . . " << respObj["feed_publisher"].toString() << endl;
-            screen << "URL  . . . . . . . " << respObj["feed_url"].toString() << endl;
-            screen << "Language . . . . . " << respObj["feed_lang"].toString() << endl;
+            screen << "[ Static Feed Information ]" << Qt::endl;
+            screen << "Publisher  . . . . " << respObj["feed_publisher"].toString() << Qt::endl;
+            screen << "URL  . . . . . . . " << respObj["feed_url"].toString() << Qt::endl;
+            screen << "Language . . . . . " << respObj["feed_lang"].toString() << Qt::endl;
             screen << "Valid Time . . . . " << "Start: " << respObj["feed_valid_start"].toString() << ", End: "
-                                            << respObj["feed_valid_end"].toString() << endl;
-            screen << "Version Text . . . " << respObj["feed_version"].toString() << endl;
-            screen << "Recs Loaded  . . . " << respObj["records"].toInt() << endl;
-            screen << endl;
+                                            << respObj["feed_valid_end"].toString() << Qt::endl;
+            screen << "Version Text . . . " << respObj["feed_version"].toString() << Qt::endl;
+            screen << "Recs Loaded  . . . " << respObj["records"].toInt() << Qt::endl;
+            screen << Qt::endl;
 
-            screen << "[ Agency Load ]" << endl;
+            screen << "[ Agency Load ]" << Qt::endl;
 
             screen.setFieldAlignment(QTextStream::AlignLeft);
             screen << qSetFieldWidth(c1) << "ID"        << qSetFieldWidth(1) << " "
                    << qSetFieldWidth(c2) << "NAME"      << qSetFieldWidth(1) << " "
                    << qSetFieldWidth(c3) << "TIMEZONE"  << qSetFieldWidth(1) << " "
-                   << qSetFieldWidth(c4) << "PHONE"     << qSetFieldWidth(0) << endl;
+                   << qSetFieldWidth(c4) << "PHONE"     << qSetFieldWidth(0) << Qt::endl;
 
             QJsonArray agencies = respObj["agencies"].toArray();
             for (const QJsonValue ag : agencies) {
@@ -225,10 +221,10 @@ void ClientGtfs::repl()
                        << qSetFieldWidth(c2) << ag["name"].toString().left(c2) << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c3) << ag["tz"].toString().left(c3)   << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c4) << ag["phone"].toString().left(c4)
-                       << qSetFieldWidth( 0) << endl;
+                       << qSetFieldWidth( 0) << Qt::endl;
             }
             screen.setFieldAlignment(QTextStream::AlignRight);
-            screen << endl;
+            screen << Qt::endl;
         }
 
         /*
@@ -249,17 +245,17 @@ void ClientGtfs::repl()
             screen << "Route List"
                    << qSetFieldWidth(this->disp.getCols() - 10)      // 10 == "Route List".length()
                    << respObj["message_time"].toString()
-                   << qSetFieldWidth(0) << endl << endl;
+                   << qSetFieldWidth(0) << Qt::endl << Qt::endl;
 
             // Useful data?
-            screen << "Query took " << respObj["proc_time_ms"].toInt() << " ms" << endl << endl;
+            screen << "Query took " << respObj["proc_time_ms"].toInt() << " ms" << Qt::endl << Qt::endl;
 
             // Start spitting out the routes
             screen.setFieldAlignment(QTextStream::AlignLeft);
             screen << qSetFieldWidth(c1) << "ID"         << qSetFieldWidth(1) << " "
                    << qSetFieldWidth(c2) << "SHORT NAME" << qSetFieldWidth(1) << " "
                    << qSetFieldWidth(c3) << "LONG NAME"  << qSetFieldWidth(1) << " "
-                   << qSetFieldWidth(c4) << "TRIPS"      << qSetFieldWidth(0) << endl;
+                   << qSetFieldWidth(c4) << "TRIPS"      << qSetFieldWidth(0) << Qt::endl;
 
             QJsonArray routes = respObj["routes"].toArray();
             for (const QJsonValue ro : routes) {
@@ -267,11 +263,11 @@ void ClientGtfs::repl()
                        << qSetFieldWidth(c2) << ro["short_name"].toString().left(c2) << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c3) << ro["long_name"].toString().left(c3)  << qSetFieldWidth(1) << " ";
                 screen.setFieldAlignment(QTextStream::AlignRight);
-                screen << qSetFieldWidth(c4) << ro["nb_trips"].toInt()               << qSetFieldWidth(0) << endl;
+                screen << qSetFieldWidth(c4) << ro["nb_trips"].toInt()               << qSetFieldWidth(0) << Qt::endl;
                 screen.setFieldAlignment(QTextStream::AlignLeft);
             }
 
-            screen << endl;
+            screen << Qt::endl;
             screen.setFieldAlignment(QTextStream::AlignRight);
         }
 
@@ -295,37 +291,37 @@ void ClientGtfs::repl()
             screen << "Trip Schedule"
                    << qSetFieldWidth(this->disp.getCols() - 13)
                    << respObj["message_time"].toString()
-                   << qSetFieldWidth(0) << endl << endl;
+                   << qSetFieldWidth(0) << Qt::endl << Qt::endl;
 
             if (respObj["error"].toInt() == 101) {
-                screen << "Trip not found in static database." << endl;
+                screen << "Trip not found in static database." << Qt::endl;
             } else if (respObj["error"].toInt() == 102) {
-                screen << "Trip not found in real-time data feed." << endl;
+                screen << "Trip not found in real-time data feed." << Qt::endl;
             } else {
                 bool realTimeData = respObj["real_time"].toBool();
 
-                screen << "Trip ID  . . . . . " << respObj["trip_id"].toString() << endl;
+                screen << "Trip ID  . . . . . " << respObj["trip_id"].toString() << Qt::endl;
                 if (!realTimeData) {
-                    screen << "Service ID . . . . " << respObj["service_id"].toString() << endl;
+                    screen << "Service ID . . . . " << respObj["service_id"].toString() << Qt::endl;
                     screen << "Validity . . . . . " << respObj["svc_start_date"].toString() << " - "
-                                                    << respObj["svc_end_date"].toString() << endl;
-                    screen << "Operating Days . . " << respObj["operate_days"].toString() << endl;
-                    screen << "Exceptions . . . . " << respObj["exception_dates"].toString() << endl;
-                    screen << "Additions  . . . . " << respObj["added_dates"].toString() << endl;
+                                                    << respObj["svc_end_date"].toString() << Qt::endl;
+                    screen << "Operating Days . . " << respObj["operate_days"].toString() << Qt::endl;
+                    screen << "Exceptions . . . . " << respObj["exception_dates"].toString() << Qt::endl;
+                    screen << "Additions  . . . . " << respObj["added_dates"].toString() << Qt::endl;
                 }
-                screen << "Route ID . . . . . " << respObj["route_id"].toString() << endl;
+                screen << "Route ID . . . . . " << respObj["route_id"].toString() << Qt::endl;
                 screen << "Route Name . . . . " << respObj["route_short_name"].toString() << ", \""
-                                                << respObj["route_long_name"].toString()  << "\"" << endl;
+                                                << respObj["route_long_name"].toString()  << "\"" << Qt::endl;
                 if (!realTimeData) {
-                    screen << "Headsign . . . . . " << respObj["headsign"].toString() << endl;
+                    screen << "Headsign . . . . . " << respObj["headsign"].toString() << Qt::endl;
                 } else {
-                    screen << "Vehicle  . . . . . " << respObj["vehicle"].toString() << endl;
+                    screen << "Vehicle  . . . . . " << respObj["vehicle"].toString() << Qt::endl;
                     screen << "Start Date&Time  . " << respObj["start_date"].toString() << " "
-                                                    << respObj["start_time"].toString() << endl;
-                    screen << "Real Time Data . . " << respObj["real_time_data_time"].toString() << endl;
+                                                    << respObj["start_time"].toString() << Qt::endl;
+                    screen << "Real Time Data . . " << respObj["real_time_data_time"].toString() << Qt::endl;
                 }
 
-                screen << "Short Name . . . . " << respObj["short_name"].toString() << endl << endl;
+                screen << "Short Name . . . . " << respObj["short_name"].toString() << Qt::endl << Qt::endl;
 
                 screen.setFieldAlignment(QTextStream::AlignLeft);
                 screen << qSetFieldWidth(c1)   << "SEQ"       << qSetFieldWidth(1) << " "
@@ -335,11 +331,11 @@ void ClientGtfs::repl()
                 if (!realTimeData) {
                     screen << qSetFieldWidth(c4*2) << "PD"        << qSetFieldWidth(1) << " "
                            << qSetFieldWidth(c5)   << "SCH-A"     << qSetFieldWidth(1) << " "
-                           << qSetFieldWidth(c6)   << "SCH-D"     << qSetFieldWidth(0) << endl;
+                           << qSetFieldWidth(c6)   << "SCH-D"     << qSetFieldWidth(0) << Qt::endl;
                 } else {
                     screen << qSetFieldWidth(c4*2) << "  "        << qSetFieldWidth(1) << " "
                            << qSetFieldWidth(c5)   << "PRE-A"     << qSetFieldWidth(1) << " "
-                           << qSetFieldWidth(c6)   << "PRE-D"     << qSetFieldWidth(0) << endl;
+                           << qSetFieldWidth(c6)   << "PRE-D"     << qSetFieldWidth(0) << Qt::endl;
                 }
 
                 QJsonArray stops = respObj["stops"].toArray();
@@ -352,12 +348,12 @@ void ClientGtfs::repl()
                            << qSetFieldWidth(c3) << st["stop_name"].toString().left(c3) << qSetFieldWidth(1) << " "
                            << qSetFieldWidth(c4) << pickUp << dropOff                   << qSetFieldWidth(1) << " ";
                     screen.setFieldAlignment(QTextStream::AlignRight);
-                    screen << qSetFieldWidth(c5) << st["arr_time"].toString()           << qSetFieldWidth(1) << " "
-                           << qSetFieldWidth(c6) << st["dep_time"].toString()           << qSetFieldWidth(0) << endl;
+                    screen << qSetFieldWidth(c5) << st["arr_time"].toString() << qSetFieldWidth(1) << " "
+                           << qSetFieldWidth(c6) << st["dep_time"].toString() << qSetFieldWidth(0) << Qt::endl;
                     screen.setFieldAlignment(QTextStream::AlignLeft);
                 }
             }
-            screen << endl;
+            screen << Qt::endl;
             screen.setFieldAlignment(QTextStream::AlignRight);
         }
 
@@ -381,16 +377,16 @@ void ClientGtfs::repl()
             screen << "Trips Serving Route"
                    << qSetFieldWidth(this->disp.getCols() - 19)
                    << respObj["message_time"].toString()
-                   << qSetFieldWidth(0) << endl << endl;
+                   << qSetFieldWidth(0) << Qt::endl << Qt::endl;
 
             if (respObj["error"].toInt() == 201) {
-                screen << "Route not found." << endl;
+                screen << "Route not found." << Qt::endl;
             }
             else {
-                screen << "Route ID . . . . . " << respObj["route_id"].toString() << endl;
+                screen << "Route ID . . . . . " << respObj["route_id"].toString() << Qt::endl;
                 screen << "Route Name . . . . " << respObj["route_short_name"].toString() << ", \""
-                                                << respObj["route_long_name"].toString()  << "\"" << endl;
-                screen << "Service Date . . . " << respObj["service_date"].toString() << endl << endl;
+                                                << respObj["route_long_name"].toString()  << "\"" << Qt::endl;
+                screen << "Service Date . . . " << respObj["service_date"].toString() << Qt::endl << Qt::endl;
 
                 // Loop on all the trips
                 screen.setFieldAlignment(QTextStream::AlignLeft);
@@ -399,38 +395,32 @@ void ClientGtfs::repl()
                        << qSetFieldWidth(c3*2+1) << "VALID-DURATION" << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c4)     << "OPERATING-DAYS" << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c5*2)   << "ES"             << qSetFieldWidth(1) << " "
-                       << qSetFieldWidth(c6)     << "SCH-D"          << qSetFieldWidth(0) << endl;
+                       << qSetFieldWidth(c6)     << "SCH-D"          << qSetFieldWidth(0) << Qt::endl;
 
                 QJsonArray trips = respObj["trips"].toArray();
                 for (const QJsonValue tr : trips) {
                     QString svcExempt = (tr["exceptions_present"].toBool())     ? "E": " ";
                     QString svcSplmnt = (tr["supplements_other_days"].toBool()) ? "S": " ";
                     QString dstOn     = " ";
-//                    if (tr["dst_on"].isBool()) {
-//                        if (tr["dst_on"].toBool()) {
-//                            dstOn = "D";
-//                        } else {
-//                            dstOn = "S";
-//                        }
-//                    }
-                    screen << qSetFieldWidth(c1) << tr["trip_id"].toString().left(c1)       << qSetFieldWidth(1) << " "
-                           << qSetFieldWidth(c2) << tr["headsign"].toString().left(c2)      << qSetFieldWidth(1) << " "
-                           << qSetFieldWidth(c3) << tr["svc_start_date"].toString()         << qSetFieldWidth(1) << "-"
-                           << qSetFieldWidth(c3) << tr["svc_end_date"].toString()           << qSetFieldWidth(1) << " "
+                    screen << qSetFieldWidth(c1) << tr["trip_id"].toString().left(c1)  << qSetFieldWidth(1) << " "
+                           << qSetFieldWidth(c2) << tr["headsign"].toString().left(c2) << qSetFieldWidth(1) << " "
+                           << qSetFieldWidth(c3) << tr["svc_start_date"].toString()    << qSetFieldWidth(1) << "-"
+                           << qSetFieldWidth(c3) << tr["svc_end_date"].toString()      << qSetFieldWidth(1) << " "
                            << qSetFieldWidth(c4) << tr["operate_days_condensed"].toString().left(c4)
                            << qSetFieldWidth(1) << " "
                            << qSetFieldWidth(c5) << svcExempt << svcSplmnt
                            << qSetFieldWidth(1) << dstOn;
                     screen.setFieldAlignment(QTextStream::AlignRight);
-                    screen << qSetFieldWidth(c6) << tr["first_stop_departure"].toString()  << qSetFieldWidth(0) << endl;
+                    screen << qSetFieldWidth(c6) << tr["first_stop_departure"].toString()
+                           << qSetFieldWidth(0) << Qt::endl;
                     screen.setFieldAlignment(QTextStream::AlignLeft);
                 }
 
-                screen << endl << "Query took " << respObj["proc_time_ms"].toInt() << " ms, "
-                       << trips.size() << " records loaded" << endl;
+                screen << Qt::endl << "Query took " << respObj["proc_time_ms"].toInt() << " ms, "
+                       << trips.size() << " records loaded" << Qt::endl;
             }
 
-            screen << endl;
+            screen << Qt::endl;
             screen.setFieldAlignment(QTextStream::AlignRight);
         }
 
@@ -455,20 +445,20 @@ void ClientGtfs::repl()
             screen << "Trips Serving Stop"
                    << qSetFieldWidth(this->disp.getCols() - 18)
                    << respObj["message_time"].toString()
-                   << qSetFieldWidth(0) << endl << endl;
+                   << qSetFieldWidth(0) << Qt::endl << Qt::endl;
 
             if (respObj["error"].toInt() == 301) {
-                screen << "Stop not found." << endl;
+                screen << "Stop not found." << Qt::endl;
             }
             else {
                 // Count how many records were returned
                 qint32 tripsLoaded = 0;
 
-                screen << "Stop ID  . . . . . " << respObj["stop_id"].toString() << endl
-                       << "Stop Name  . . . . " << respObj["stop_name"].toString() << endl
-                       << "Stop Desc  . . . . " << respObj["stop_desc"].toString() << endl
-                       << "Parent Station . . " << respObj["parent_sta"].toString() << endl
-                       << "Service Date . . . " << respObj["service_date"].toString() << endl << endl;
+                screen << "Stop ID  . . . . . " << respObj["stop_id"].toString() << Qt::endl
+                       << "Stop Name  . . . . " << respObj["stop_name"].toString() << Qt::endl
+                       << "Stop Desc  . . . . " << respObj["stop_desc"].toString() << Qt::endl
+                       << "Parent Station . . " << respObj["parent_sta"].toString() << Qt::endl
+                       << "Service Date . . . " << respObj["service_date"].toString() << Qt::endl << Qt::endl;
 
                 // ... then all the trips within each route
                 screen.setFieldAlignment(QTextStream::AlignLeft);
@@ -478,14 +468,14 @@ void ClientGtfs::repl()
                        << qSetFieldWidth(c4*2+1) << "VALID-DURATION" << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c5)     << "OPERATING-DAYS" << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c6*5)   << "ES TPD"         << qSetFieldWidth(1) << " "
-                       << qSetFieldWidth(c7)     << "SCH-D"          << qSetFieldWidth(0) << endl << endl;
+                       << qSetFieldWidth(c7)     << "SCH-D"          << qSetFieldWidth(0) << Qt::endl << Qt::endl;
 
                 // Loop on all the routes
                 QJsonArray routes = respObj["routes"].toArray();
                 for (const QJsonValue ro : routes) {
                     screen << "[ Route ID " << ro["route_id"].toString() << " :: "
                                             << ro["route_short_name"].toString() << " :: "
-                                            << ro["route_long_name"].toString()  << " ]"   << endl;
+                                            << ro["route_long_name"].toString()  << " ]"   << Qt::endl;
 
                     // Loop on all the trips
                     QJsonArray trips = ro["trips"].toArray();
@@ -522,18 +512,18 @@ void ClientGtfs::repl()
                                << qSetFieldWidth(c6) << svcExempt << svcSplmnt << " " << tripTerm << pickUp << dropOff
                                << qSetFieldWidth(1) << dstIndic;
                         screen.setFieldAlignment(QTextStream::AlignRight);
-                        screen << qSetFieldWidth(c7) << tr["dep_time"].toString() << qSetFieldWidth(0) << endl;
+                        screen << qSetFieldWidth(c7) << tr["dep_time"].toString() << qSetFieldWidth(0) << Qt::endl;
                         screen.setFieldAlignment(QTextStream::AlignLeft);
                     } // End loop on Trips-within-Route
                     tripsLoaded += trips.size();
-                    screen << endl;
+                    screen << Qt::endl;
                 } // End loop on Routes-serving-Stop
 
                 screen << "Query took " << respObj["proc_time_ms"].toInt() << " ms, "
-                       << tripsLoaded << " trips loaded" << endl;
+                       << tripsLoaded << " trips loaded" << Qt::endl;
             }
 
-            screen << endl;
+            screen << Qt::endl;
             screen.setFieldAlignment(QTextStream::AlignRight);
         }
 
@@ -554,25 +544,25 @@ void ClientGtfs::repl()
             screen << "Individual Stop Service Information"
                    << qSetFieldWidth(this->disp.getCols() - 35)
                    << respObj["message_time"].toString()
-                   << qSetFieldWidth(0) << endl << endl;
+                   << qSetFieldWidth(0) << Qt::endl << Qt::endl;
 
             if (respObj["error"].toInt() == 401) {
-                screen << "Stop not found." << endl;
+                screen << "Stop not found." << Qt::endl;
             }
             else {
                 screen << "Stop ID/Name . . . " << respObj["stop_id"].toString() << " :: "
-                                                << respObj["stop_name"].toString() << endl;
-                screen << "Stop Desc  . . . . " << respObj["stop_desc"].toString() << endl;
+                                                << respObj["stop_name"].toString() << Qt::endl;
+                screen << "Stop Desc  . . . . " << respObj["stop_desc"].toString() << Qt::endl;
                 screen << "Location . . . . . " << respObj["loc_lat"].toString() << ", "
-                                                << respObj["loc_lon"].toString() << endl;
-                screen << "Parent Station . . " << respObj["parent_sta"].toString() << endl << endl;
+                                                << respObj["loc_lon"].toString() << Qt::endl;
+                screen << "Parent Station . . " << respObj["parent_sta"].toString() << Qt::endl << Qt::endl;
 
                 // Show all the Routes associated with the station requested
                 screen.setFieldAlignment(QTextStream::AlignLeft);
-                screen << "[ Routes Serving Stop ]" << endl;
+                screen << "[ Routes Serving Stop ]" << Qt::endl;
                 screen << qSetFieldWidth(c1) << "ROUTE-ID"         << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c2) << "ROUTE-NAME-SHORT" << qSetFieldWidth(1) << " "
-                       << qSetFieldWidth(c3) << "ROUTE-NAME-LONG"  << qSetFieldWidth(1) << endl;
+                       << qSetFieldWidth(c3) << "ROUTE-NAME-LONG"  << qSetFieldWidth(1) << Qt::endl;
 
                 // Loop on all the routes
                 QJsonArray routes = respObj["routes"].toArray();
@@ -582,28 +572,29 @@ void ClientGtfs::repl()
                            << qSetFieldWidth(c2) << ro["route_short_name"].toString().left(c2)
                            << qSetFieldWidth(1) << " "
                            << qSetFieldWidth(c3) << ro["route_long_name"].toString().left(c3)
-                           << qSetFieldWidth(0) << endl;
+                           << qSetFieldWidth(0) << Qt::endl;
                 }
-                screen << endl;
+                screen << Qt::endl;
 
                 // Then display any associated stations with the parent
                 screen.setFieldAlignment(QTextStream::AlignLeft);
-                screen << "[ Stops Sharing Parent Station ]" << endl;
+                screen << "[ Stops Sharing Parent Station ]" << Qt::endl;
                 screen << qSetFieldWidth(c1) << "STOP-ID"   << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c2) << "STOP-NAME" << qSetFieldWidth(1) << " "
-                       << qSetFieldWidth(c3) << "STOP-DESC" << qSetFieldWidth(1) << endl;
+                       << qSetFieldWidth(c3) << "STOP-DESC" << qSetFieldWidth(1) << Qt::endl;
 
                 QJsonArray sharedStops = respObj["stops_sharing_parent"].toArray();
                 for (const QJsonValue ss : sharedStops) {
                     screen << qSetFieldWidth(c1) << ss["stop_id"].toString().left(c1)   << qSetFieldWidth(1) << " "
                            << qSetFieldWidth(c2) << ss["stop_name"].toString().left(c2) << qSetFieldWidth(1) << " "
-                           << qSetFieldWidth(c3) << ss["stop_desc"].toString().left(c3) << qSetFieldWidth(0) << endl;
+                           << qSetFieldWidth(c3) << ss["stop_desc"].toString().left(c3)
+                           << qSetFieldWidth(0)  << Qt::endl;
                 }
-                screen << endl;
-                screen << "Query took " << respObj["proc_time_ms"].toInt() << " ms" << endl;
+                screen << Qt::endl;
+                screen << "Query took " << respObj["proc_time_ms"].toInt() << " ms" << Qt::endl;
             }
 
-            screen << endl;
+            screen << Qt::endl;
             screen.setFieldAlignment(QTextStream::AlignRight);
         }
 
@@ -626,29 +617,29 @@ void ClientGtfs::repl()
             screen << "Route Summary and Stop Information"
                    << qSetFieldWidth(this->disp.getCols() - 34)
                    << respObj["message_time"].toString()
-                   << qSetFieldWidth(0) << endl << endl;
+                   << qSetFieldWidth(0) << Qt::endl << Qt::endl;
 
             if (respObj["error"].toInt() == 501) {
-                screen << "Route not found." << endl;
+                screen << "Route not found." << Qt::endl;
             }
             else {
-                screen << "Route ID . . . . . " << respObj["route_id"].toString() << endl
-                       << "Short Name . . . . " << respObj["route_short_name"].toString() << endl
-                       << "Long Name  . . . . " << respObj["route_long_name"].toString() << endl
-                       << "Description  . . . " << respObj["route_desc"].toString() << endl
-                       << "Type . . . . . . . " << respObj["route_type"].toString() << endl
-                       << "URL  . . . . . . . " << respObj["route_url"].toString() << endl
-                       << "Color  . . . . . . " << respObj["route_color"].toString() << endl
-                       << "Text Color . . . . " << respObj["route_text_color"].toString() << endl << endl;
+                screen << "Route ID . . . . . " << respObj["route_id"].toString() << Qt::endl
+                       << "Short Name . . . . " << respObj["route_short_name"].toString() << Qt::endl
+                       << "Long Name  . . . . " << respObj["route_long_name"].toString() << Qt::endl
+                       << "Description  . . . " << respObj["route_desc"].toString() << Qt::endl
+                       << "Type . . . . . . . " << respObj["route_type"].toString() << Qt::endl
+                       << "URL  . . . . . . . " << respObj["route_url"].toString() << Qt::endl
+                       << "Color  . . . . . . " << respObj["route_color"].toString() << Qt::endl
+                       << "Text Color . . . . " << respObj["route_text_color"].toString() << Qt::endl << Qt::endl;
 
                 // Show all the Routes associated with the station requested
                 screen.setFieldAlignment(QTextStream::AlignLeft);
-                screen << "[ Stops Served by Route ]" << endl;
+                screen << "[ Stops Served by Route ]" << Qt::endl;
                 screen << qSetFieldWidth(c1)     << "STOP-ID"   << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c2)     << "STOP-NAME" << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c3)     << "STOP-DESC" << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c4)     << "#TRIPS"    << qSetFieldWidth(1) << " "
-                       << qSetFieldWidth(c5 * 2) << "LOCATION"  << qSetFieldWidth(1) << endl;
+                       << qSetFieldWidth(c5 * 2) << "LOCATION"  << qSetFieldWidth(1) << Qt::endl;
 
                 // Loop on all the routes
                 QJsonArray stops = respObj["stops"].toArray();
@@ -659,10 +650,11 @@ void ClientGtfs::repl()
                     screen.setFieldAlignment(QTextStream::AlignRight);
                     screen << qSetFieldWidth(c4) << so["trip_count"].toInt()            << qSetFieldWidth(1) << " "
                            << qSetFieldWidth(c5) << so["stop_lat"].toString().left(c5)  << qSetFieldWidth(1) << ","
-                           << qSetFieldWidth(c5) << so["stop_lon"].toString().left(c5)  << qSetFieldWidth(0) << endl;
+                           << qSetFieldWidth(c5) << so["stop_lon"].toString().left(c5)
+                           << qSetFieldWidth(0)  << Qt::endl;
                     screen.setFieldAlignment(QTextStream::AlignLeft);
                 }
-                screen << endl;
+                screen << Qt::endl;
             }
             screen.setFieldAlignment(QTextStream::AlignRight);
         }
@@ -688,18 +680,18 @@ void ClientGtfs::repl()
             screen << "Upcoming Service at Stop"
                    << qSetFieldWidth(this->disp.getCols() - 24)
                    << respObj["message_time"].toString()
-                   << qSetFieldWidth(0) << endl << endl;
+                   << qSetFieldWidth(0) << Qt::endl << Qt::endl;
 
             if (respObj["error"].toInt() == 601) {
-                screen << "Stop not found." << endl;
+                screen << "Stop not found." << Qt::endl;
             }
             else {
                 // Count how many records were returned
                 qint32 tripsLoaded = 0;
 
-                screen << "Stop ID  . . . . . " << respObj["stop_id"].toString()   << endl
-                       << "Stop Name  . . . . " << respObj["stop_name"].toString() << endl
-                       << "Stop Desc  . . . . " << respObj["stop_desc"].toString() << endl << endl;
+                screen << "Stop ID  . . . . . " << respObj["stop_id"].toString()   << Qt::endl
+                       << "Stop Name  . . . . " << respObj["stop_name"].toString() << Qt::endl
+                       << "Stop Desc  . . . . " << respObj["stop_desc"].toString() << Qt::endl << Qt::endl;
 
                 // ... then all the trips within each route
                 screen.setFieldAlignment(QTextStream::AlignLeft);
@@ -709,12 +701,12 @@ void ClientGtfs::repl()
                        << qSetFieldWidth(c4*3) << "TPD"       << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c5)   << "STOP-TIME" << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c6)   << "MINS"      << qSetFieldWidth(1) << " "
-                       << qSetFieldWidth(c7)   << "STAT"      << qSetFieldWidth(0) << endl;
+                       << qSetFieldWidth(c7)   << "STAT"      << qSetFieldWidth(0) << Qt::endl;
 
                 // Loop on all the routes
                 QJsonArray routes = respObj["routes"].toArray();
                 for (const QJsonValue ro : routes) {
-                    screen << "[ Route ID " << ro["route_id"].toString() << " ]"   << endl;
+                    screen << "[ Route ID " << ro["route_id"].toString() << " ]"   << Qt::endl;
 
                     // Loop on all the trips
                     QJsonArray trips = ro["trips"].toArray();
@@ -802,7 +794,7 @@ void ClientGtfs::repl()
                                     if (offsetSec < -60 || offsetSec > 60) {
                                         screen.setNumberFlags(QTextStream::ForceSign);
                                         screen << qSetFieldWidth(c7) << offsetSec / 60 << qSetFieldWidth(0);
-                                        noforcesign(screen);
+                                        Qt::noforcesign(screen);
                                     } else {
                                         screen << qSetFieldWidth(c7) << "ONTM" << qSetFieldWidth(0);
                                     }
@@ -823,19 +815,19 @@ void ClientGtfs::repl()
                         }
 
                         screen.setFieldAlignment(QTextStream::AlignLeft);
-                        screen << endl;
+                        screen << Qt::endl;
 
                     } // End loop on Trips-within-Route
 
                     tripsLoaded += trips.size();
-                    screen << endl;
+                    screen << Qt::endl;
                 } // End loop on Routes-serving-Stop
 
                 screen << "Query took " << respObj["proc_time_ms"].toInt() << " ms, "
-                       << tripsLoaded << " trips loaded" << endl;
+                       << tripsLoaded << " trips loaded" << Qt::endl;
             }
 
-            screen << endl;
+            screen << Qt::endl;
             screen.setFieldAlignment(QTextStream::AlignRight);
         }
 
@@ -861,18 +853,18 @@ void ClientGtfs::repl()
             screen << "Upcoming Service at Stop"
                    << qSetFieldWidth(this->disp.getCols() - 24)
                    << respObj["message_time"].toString()
-                   << qSetFieldWidth(0) << endl << endl;
+                   << qSetFieldWidth(0) << Qt::endl << Qt::endl;
 
             if (respObj["error"].toInt() == 601) {
-                screen << "Stop not found." << endl;
+                screen << "Stop not found." << Qt::endl;
             }
             else {
                 // Count how many records were returned
                 qint32 tripsLoaded = 0;
 
-                screen << "Stop ID  . . . . . " << respObj["stop_id"].toString()   << endl
-                       << "Stop Name  . . . . " << respObj["stop_name"].toString() << endl
-                       << "Stop Desc  . . . . " << respObj["stop_desc"].toString() << endl << endl;
+                screen << "Stop ID  . . . . . " << respObj["stop_id"].toString()   << Qt::endl
+                       << "Stop Name  . . . . " << respObj["stop_name"].toString() << Qt::endl
+                       << "Stop Desc  . . . . " << respObj["stop_desc"].toString() << Qt::endl << Qt::endl;
 
                 // ... then all the trips within each route
                 screen.setFieldAlignment(QTextStream::AlignLeft);
@@ -883,7 +875,7 @@ void ClientGtfs::repl()
                        << qSetFieldWidth(c5*3) << "TPD"       << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c6)   << "STOP-TIME" << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c7)   << "MINS"      << qSetFieldWidth(1) << " "
-                       << qSetFieldWidth(c8)   << "STAT"      << qSetFieldWidth(0) << endl;
+                       << qSetFieldWidth(c8)   << "STAT"      << qSetFieldWidth(0) << Qt::endl;
 
                 // Loop on all the trips
                 QJsonArray trips = respObj["trips"].toArray();
@@ -972,7 +964,7 @@ void ClientGtfs::repl()
                                 if (offsetSec < -60 || offsetSec > 60) {
                                     screen.setNumberFlags(QTextStream::ForceSign);
                                     screen << qSetFieldWidth(c8) << offsetSec / 60 << qSetFieldWidth(0);
-                                    noforcesign(screen);
+                                    Qt::noforcesign(screen);
                                 } else {
                                     screen << qSetFieldWidth(c8) << "ONTM" << qSetFieldWidth(0);
                                 }
@@ -993,18 +985,18 @@ void ClientGtfs::repl()
                     }
 
                     screen.setFieldAlignment(QTextStream::AlignLeft);
-                    screen << endl;
+                    screen << Qt::endl;
 
                 } // End loop on Trips-within-Route
 
                 tripsLoaded += trips.size();
-                screen << endl;
+                screen << Qt::endl;
 
                 screen << "Query took " << respObj["proc_time_ms"].toInt() << " ms, "
-                       << tripsLoaded << " trips loaded" << endl;
+                       << tripsLoaded << " trips loaded" << Qt::endl;
             }
 
-            screen << endl;
+            screen << Qt::endl;
             screen.setFieldAlignment(QTextStream::AlignRight);
         }
 
@@ -1026,13 +1018,13 @@ void ClientGtfs::repl()
             screen << "Stops Without Trips"
                    << qSetFieldWidth(this->disp.getCols() - 19)
                    << respObj["message_time"].toString()
-                   << qSetFieldWidth(0) << endl << endl;
+                   << qSetFieldWidth(0) << Qt::endl << Qt::endl;
 
             screen.setFieldAlignment(QTextStream::AlignLeft);
             screen << qSetFieldWidth(c1) << "STOP-ID"   << qSetFieldWidth(1) << " "
                    << qSetFieldWidth(c2) << "STOP-NAME" << qSetFieldWidth(1) << " "
                    << qSetFieldWidth(c3) << "STOP-DESC" << qSetFieldWidth(1) << " "
-                   << qSetFieldWidth(c4) << "LOCATION"  << qSetFieldWidth(1) << endl;
+                   << qSetFieldWidth(c4) << "LOCATION"  << qSetFieldWidth(1) << Qt::endl;
 
             // Loop on all the routes
             QJsonArray stops = respObj["stops"].toArray();
@@ -1047,10 +1039,10 @@ void ClientGtfs::repl()
                 screen << qSetFieldWidth(c4/2) << st["loc_lat"].toString().left(c4/2)
                        << qSetFieldWidth(1)    << ","
                        << qSetFieldWidth(c4/2) << st["loc_lon"].toString().left(c4/2)
-                       << qSetFieldWidth(0)    << endl;
+                       << qSetFieldWidth(0)    << Qt::endl;
                 screen.setFieldAlignment(QTextStream::AlignLeft);
             }
-            screen << endl << "Query took " << respObj["proc_time_ms"].toInt() << " ms" << endl << endl;
+            screen << Qt::endl << "Query took " << respObj["proc_time_ms"].toInt() << " ms" << Qt::endl << Qt::endl;
             screen.setFieldAlignment(QTextStream::AlignRight);
         }
 
@@ -1070,40 +1062,40 @@ void ClientGtfs::repl()
             screen << "GTFS Realtime Data Status"
                    << qSetFieldWidth(this->disp.getCols() - 25)
                    << respObj["message_time"].toString()
-                   << qSetFieldWidth(0) << endl << endl;
+                   << qSetFieldWidth(0) << Qt::endl << Qt::endl;
 
             screen.setFieldAlignment(QTextStream::AlignLeft);
 
             // Mutual Exclusion
-            screen << "[ Mutual Exclusion ]" << endl
-                   << "Active Side  . . . " << respObj["active_side"].toString() << endl
-                   << "Data Age . . . . . " << respObj["active_age_sec"].toInt() << " s" << endl
-                   << "Feed Time  . . . . " << respObj["active_feed_time"].toString() << endl
-                   << "Download Time  . . " << respObj["active_download_ms"].toInt() << " ms" << endl
-                   << "Integ Time . . . . " << respObj["active_integration_ms"].toInt() << " ms" << endl
-                   << "Next Fetch In  . . " << respObj["seconds_to_next_fetch"].toInt() << " s" << endl
-                   << "Latest RT Txn  . . " << respObj["last_realtime_query"].toString() << endl
-                   << endl << endl;
+            screen << "[ Mutual Exclusion ]" << Qt::endl
+                   << "Active Side  . . . " << respObj["active_side"].toString() << Qt::endl
+                   << "Data Age . . . . . " << respObj["active_age_sec"].toInt() << " s" << Qt::endl
+                   << "Feed Time  . . . . " << respObj["active_feed_time"].toString() << Qt::endl
+                   << "Download Time  . . " << respObj["active_download_ms"].toInt() << " ms" << Qt::endl
+                   << "Integ Time . . . . " << respObj["active_integration_ms"].toInt() << " ms" << Qt::endl
+                   << "Next Fetch In  . . " << respObj["seconds_to_next_fetch"].toInt() << " s" << Qt::endl
+                   << "Latest RT Txn  . . " << respObj["last_realtime_query"].toString() << Qt::endl
+                   << Qt::endl << Qt::endl;
 
 
             screen << qSetFieldWidth(c1) << "TRIP-ID"   << qSetFieldWidth(1) << " "
-                   << qSetFieldWidth(c2) << "ROUTE-ID"  << qSetFieldWidth(1) << endl;
+                   << qSetFieldWidth(c2) << "ROUTE-ID"  << qSetFieldWidth(1) << Qt::endl;
 
             // Loop on all the routes
             //QJsonArray stops = respObj["stops"].toArray();
 
-            screen << endl << "Query took " << respObj["proc_time_ms"].toInt() << " ms" << endl << endl;
+            screen << Qt::endl << "Query took " << respObj["proc_time_ms"].toInt() << " ms" << Qt::endl << Qt::endl;
             screen.setFieldAlignment(QTextStream::AlignRight);
         }
 
         // Probably some kind of error condition, just respond in kind
         else {
-            screen << endl << "No handler for the request: " << endl << responseStr << endl;
+            screen << Qt::endl << "No handler for the request: " << Qt::endl << responseStr << Qt::endl;
         }
     }
 
     // On exit (loop halted above)
-    screen << "*** DISCONNECTING ***" << endl;
+    screen << "*** DISCONNECTING ***" << Qt::endl;
 }
 
 QString ClientGtfs::dropoffToChar(qint8 svcDropOff)

--- a/client_cli/clientgtfs.h
+++ b/client_cli/clientgtfs.h
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/client_cli/structureddisplay.cpp
+++ b/client_cli/structureddisplay.cpp
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *
@@ -70,42 +70,42 @@ void Display::displayWelcome()
     //
     QTextStream screen(stdout);
     screen << buffer << "GTFS Interactive Data Console -- Version: "
-                     << QCoreApplication::applicationVersion() << endl
-           << endl
-           << "[ System Information ]" << endl
-           << "SDS: Backend system and data load status" << endl
-           << "RDS: GTFS Real-Time data retrieval status" << endl
-           << "RTE: Routes available from the data set" << endl
-           << "SSR: List of all stops served by a single route" << endl
-           << "SNT: List all stops that have no trips (diagnostic)" << endl
-           << endl
-           << "[ Full Schedule Lookup ]" << endl
-           << "STA: Stop information lookup by stop_id" << endl
-           << "TSR: List of trips serving a route_id" << endl
-           << "TSS: List of trips serving a stop_id" << endl
-           << "TRI: List all the stops served by a trip_id" << endl
-           << "RTS/RTF/RTT: List the real-time data of an active trip_id or update" << endl
-           << endl
-           << "[ Data Lookup for Specific Date ]" << endl
-           << "TRD: List of trips serving a route_id on a date" << endl
-           << "TSD: List of trips serving a stop_id on a date" << endl
-           << "NEX: List upcoming trips serving a stop_id within a number of minutes" << endl
-           << endl
+                     << QCoreApplication::applicationVersion() << Qt::endl
+           << Qt::endl
+           << "[ System Information ]" << Qt::endl
+           << "SDS: Backend system and data load status" << Qt::endl
+           << "RDS: GTFS Real-Time data retrieval status" << Qt::endl
+           << "RTE: Routes available from the data set" << Qt::endl
+           << "SSR: List of all stops served by a single route" << Qt::endl
+           << "SNT: List all stops that have no trips (diagnostic)" << Qt::endl
+           << Qt::endl
+           << "[ Full Schedule Lookup ]" << Qt::endl
+           << "STA: Stop information lookup by stop_id" << Qt::endl
+           << "TSR: List of trips serving a route_id" << Qt::endl
+           << "TSS: List of trips serving a stop_id" << Qt::endl
+           << "TRI: List all the stops served by a trip_id" << Qt::endl
+           << "RTS/RTF/RTT: List the real-time data of an active trip_id or update" << Qt::endl
+           << Qt::endl
+           << "[ Data Lookup for Specific Date ]" << Qt::endl
+           << "TRD: List of trips serving a route_id on a date" << Qt::endl
+           << "TSD: List of trips serving a stop_id on a date" << Qt::endl
+           << "NEX: List upcoming trips serving a stop_id within a number of minutes" << Qt::endl
+           << Qt::endl
            << "Reinitialize the display with 'HOM', quit using 'BYE'"
-           << endl << endl;
+           << Qt::endl << Qt::endl;
 }
 
 void Display::showServer(QString hostname, int port)
 {
     QTextStream screen(stdout);
-    screen << "Connected to: " << hostname << " : " << port << endl;
+    screen << "Connected to: " << hostname << " : " << port << Qt::endl;
     screen.flush();
 }
 
 void Display::showError(QString errorText)
 {
     QTextStream screen(stdout);
-    screen << "Error: " << errorText << endl;
+    screen << "Error: " << errorText << Qt::endl;
     screen.flush();
 }
 

--- a/client_cli/structureddisplay.h
+++ b/client_cli/structureddisplay.h
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_modules/availableroutes.cpp
+++ b/gtfs_modules/availableroutes.cpp
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_modules/availableroutes.h
+++ b/gtfs_modules/availableroutes.h
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_modules/realtimeproductstatus.cpp
+++ b/gtfs_modules/realtimeproductstatus.cpp
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_modules/realtimeproductstatus.h
+++ b/gtfs_modules/realtimeproductstatus.h
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_modules/realtimestatus.cpp
+++ b/gtfs_modules/realtimestatus.cpp
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_modules/realtimestatus.h
+++ b/gtfs_modules/realtimestatus.h
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_modules/realtimetripinformation.cpp
+++ b/gtfs_modules/realtimetripinformation.cpp
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_modules/realtimetripinformation.h
+++ b/gtfs_modules/realtimetripinformation.h
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_modules/servicebetweenstops.cpp
+++ b/gtfs_modules/servicebetweenstops.cpp
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_modules/servicebetweenstops.h
+++ b/gtfs_modules/servicebetweenstops.h
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_modules/staticstatus.cpp
+++ b/gtfs_modules/staticstatus.cpp
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_modules/staticstatus.h
+++ b/gtfs_modules/staticstatus.h
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_modules/stationdetailsdisplay.cpp
+++ b/gtfs_modules/stationdetailsdisplay.cpp
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_modules/stationdetailsdisplay.h
+++ b/gtfs_modules/stationdetailsdisplay.h
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_modules/stopsservedbyroute.cpp
+++ b/gtfs_modules/stopsservedbyroute.cpp
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_modules/stopsservedbyroute.h
+++ b/gtfs_modules/stopsservedbyroute.h
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_modules/stopswithouttrips.cpp
+++ b/gtfs_modules/stopswithouttrips.cpp
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_modules/stopswithouttrips.h
+++ b/gtfs_modules/stopswithouttrips.h
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_modules/tripscheduledisplay.cpp
+++ b/gtfs_modules/tripscheduledisplay.cpp
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_modules/tripscheduledisplay.h
+++ b/gtfs_modules/tripscheduledisplay.h
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_modules/tripsservingroute.cpp
+++ b/gtfs_modules/tripsservingroute.cpp
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_modules/tripsservingroute.h
+++ b/gtfs_modules/tripsservingroute.h
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_modules/tripsservingstop.cpp
+++ b/gtfs_modules/tripsservingstop.cpp
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_modules/tripsservingstop.h
+++ b/gtfs_modules/tripsservingstop.h
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_modules/upcomingstopservice.cpp
+++ b/gtfs_modules/upcomingstopservice.cpp
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_modules/upcomingstopservice.h
+++ b/gtfs_modules/upcomingstopservice.h
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_process/csvprocessor.cpp
+++ b/gtfs_process/csvprocessor.cpp
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_process/csvprocessor.h
+++ b/gtfs_process/csvprocessor.h
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_process/datagateway.cpp
+++ b/gtfs_process/datagateway.cpp
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_process/datagateway.h
+++ b/gtfs_process/datagateway.h
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_process/gtfsroute.cpp
+++ b/gtfs_process/gtfsroute.cpp
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_process/gtfsroute.h
+++ b/gtfs_process/gtfsroute.h
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_process/gtfsstatus.cpp
+++ b/gtfs_process/gtfsstatus.cpp
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *
@@ -131,8 +131,8 @@ Status::Status(const QString dataRootPath,
                          brokenDateParams.at(4).toInt(),
                          brokenDateParams.at(5).toInt());
         frozenAgencyTime = QDateTime(frozenDate, frozenTime, this->serverFeedTZ);
-        qDebug() << endl << "TESTING/DEBUGGING/ANALYSIS MODE: All transaction will be processed as if it is "
-                 << frozenAgencyTime << endl;
+        qDebug() << Qt::endl << "TESTING/DEBUGGING/ANALYSIS MODE: All transaction will be processed as if it is "
+                 << frozenAgencyTime << Qt::endl;
     }
 
     // Show all times with AM/PM indicator instead of standard 24-hour clock

--- a/gtfs_process/gtfsstatus.h
+++ b/gtfs_process/gtfsstatus.h
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_process/gtfsstops.cpp
+++ b/gtfs_process/gtfsstops.cpp
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_process/gtfsstops.h
+++ b/gtfs_process/gtfsstops.h
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_process/gtfsstoptimes.cpp
+++ b/gtfs_process/gtfsstoptimes.cpp
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_process/gtfsstoptimes.h
+++ b/gtfs_process/gtfsstoptimes.h
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_process/gtfstrip.cpp
+++ b/gtfs_process/gtfstrip.cpp
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_process/gtfstrip.h
+++ b/gtfs_process/gtfstrip.h
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_process/operatingday.cpp
+++ b/gtfs_process/operatingday.cpp
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_process/operatingday.h
+++ b/gtfs_process/operatingday.h
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_process/tripstopreconciler.cpp
+++ b/gtfs_process/tripstopreconciler.cpp
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_process/tripstopreconciler.cpp
+++ b/gtfs_process/tripstopreconciler.cpp
@@ -141,6 +141,10 @@ void TripStopReconciler::getTripsByRoute(QHash<QString, StopRecoRouteRec> &route
         for (const QString &routeID : fullTrips.keys()) {
             for (StopRecoTripRec &tripRecord : fullTrips[routeID].tripRecos) {
                 QDate dateUsedByRT;
+
+                // Do not return undefined values for offset for canceled / skipping-stop trips
+                tripRecord.realTimeOffsetSec = 0;
+
                 if (rActiveFeed->scheduledTripIsRunning(tripRecord.tripID,
                                                         tripRecord.tripServiceDate,
                                                         tripRecord.tripFirstDeparture.date(),
@@ -489,14 +493,14 @@ void TripStopReconciler::invalidateTrips(const QString                    &route
 }
 
 void TripStopReconciler::fillStopStatWaitTimeOffset(const QDateTime &schArrUTC,
-                                                       const QDateTime &schDepUTC,
-                                                       const QDateTime &preArrUTC,
-                                                       const QDateTime &preDepUTC,
-                                                       QString         &tripStopStatus,
-                                                       qint64          &waitTimeSeconds,
-                                                       qint64          &realTimeOffsetSec,
-                                                       QDateTime       &realTimeArrLT,
-                                                       QDateTime       &realTimeDepLT) const
+                                                    const QDateTime &schDepUTC,
+                                                    const QDateTime &preArrUTC,
+                                                    const QDateTime &preDepUTC,
+                                                    QString         &tripStopStatus,
+                                                    qint64          &waitTimeSeconds,
+                                                    qint64          &realTimeOffsetSec,
+                                                    QDateTime       &realTimeArrLT,
+                                                    QDateTime       &realTimeDepLT) const
 {
     /*
      * There are 3 different flags an operating trip may have based on the presence of both the

--- a/gtfs_process/tripstopreconciler.h
+++ b/gtfs_process/tripstopreconciler.h
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_realtime/gtfsrealtimefeed.cpp
+++ b/gtfs_realtime/gtfsrealtimefeed.cpp
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *
@@ -788,9 +788,9 @@ void RealTimeTripUpdate::showProtobufData() const
     google::protobuf::TextFormat::PrintToString(_tripUpdate, &data);
     qDebug() << "GTFS-Realtime : LOCAL DEBUGGING MODE";
     qDebug() << "-----[ CONTENTS ]------------------------------------------------------------------------------------";
-    qDebug() << data.c_str() << endl
+    qDebug() << data.c_str() << Qt::endl
              << "-----------------------------------------------------------------------[ END PROTOBUF CONTENTS ]-----";
-    qDebug() << "Protobuf: " << _tripUpdate.ByteSize() << " bytes" << endl;
+    qDebug() << "Protobuf: " << _tripUpdate.ByteSize() << " bytes" << Qt::endl;
     qDebug() << "Processing _tripUpdate.entity_size() = " << _tripUpdate.entity_size() << "real-time records.";
 }
 

--- a/gtfs_realtime/gtfsrealtimefeed.h
+++ b/gtfs_realtime/gtfsrealtimefeed.h
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_realtime/gtfsrealtimegateway.cpp
+++ b/gtfs_realtime/gtfsrealtimegateway.cpp
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfs_realtime/gtfsrealtimegateway.h
+++ b/gtfs_realtime/gtfsrealtimegateway.h
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfsproc/gtfsrequestprocessor.cpp
+++ b/gtfsproc/gtfsrequestprocessor.cpp
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfsproc/gtfsrequestprocessor.h
+++ b/gtfsproc/gtfsrequestprocessor.h
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfsproc/servegtfs.cpp
+++ b/gtfsproc/servegtfs.cpp
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *
@@ -106,7 +106,7 @@ ServeGTFS::~ServeGTFS()
 void ServeGTFS::displayDebugging() const
 {
     const GTFS::Status *data = GTFS::DataGateway::inst().getStatus();
-    qDebug() << endl << "[ GTFS Static Data Information ]";
+    qDebug() << Qt::endl << "[ GTFS Static Data Information ]";
     qDebug() << "Recs Loaded . . . ." << data->getRecordsLoaded();
     qDebug() << "Server Start Time ." << data->getServerStartTimeUTC();
     qDebug() << "Feed Publisher  . ." << data->getPublisher();
@@ -114,7 +114,7 @@ void ServeGTFS::displayDebugging() const
     qDebug() << "Feed Language . . ." << data->getLanguage();
     qDebug() << "Feed Start Date . ." << data->getStartDate().toString("dd-MMM-yyyy");
     qDebug() << "Feed End Date . . ." << data->getEndDate().toString("dd-MMM-yyyy");
-    qDebug() << "Feed Version  . . ." << data->getVersion() << endl;
+    qDebug() << "Feed Version  . . ." << data->getVersion() << Qt::endl;
 }
 
 void ServeGTFS::incomingConnection(qintptr descriptor)

--- a/gtfsproc/servegtfs.h
+++ b/gtfsproc/servegtfs.h
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *

--- a/gtfsproc/server_main.cpp
+++ b/gtfsproc/server_main.cpp
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2020, Daniel Brook
+ * Copyright (C) 2018-2021, Daniel Brook
  *
  * This file is part of GtfsProc.
  *
@@ -33,14 +33,14 @@ int main(int argc, char *argv[])
      */
     QCoreApplication a(argc, argv);
     QCoreApplication::setApplicationName("GtfsProc");
-    QCoreApplication::setApplicationVersion("1.8");
+    QCoreApplication::setApplicationVersion("1.8b");
 
     QTextStream console(stdout);
     QString appName = QCoreApplication::applicationName();
     QString appVers = QCoreApplication::applicationVersion();
 
     console << appName.remove("\"") << " version " << appVers.remove("\"")
-            << " - Running on Process ID: " << QCoreApplication::applicationPid() << endl << endl;
+            << " - Running on Process ID: " << QCoreApplication::applicationPid() << Qt::endl << Qt::endl;
 
     /*
      * Command Line Parsing
@@ -197,10 +197,10 @@ int main(int argc, char *argv[])
      * BEGIN LISTENING FOR CONNECTIONS
      */
     if (gtfsRequestServer.listen(QHostAddress::Any, portNum)) {
-        console << "SERVER STARTED - READY TO ACCEPT INCOMING CONNECTIONS" << endl << endl;
+        console << "SERVER STARTED - READY TO ACCEPT INCOMING CONNECTIONS" << Qt::endl << Qt::endl;
     } else {
         console << gtfsRequestServer.errorString();
-        console << endl << "(!) COULD NOT START SERVER - SEE ERROR STRING ABOVE" << endl;
+        console << Qt::endl << "(!) COULD NOT START SERVER - SEE ERROR STRING ABOVE" << Qt::endl;
         return 1;
     }
 

--- a/tests/CTTransit/stop_sequence_vs_stop_id_matching.test
+++ b/tests/CTTransit/stop_sequence_vs_stop_id_matching.test
@@ -62,7 +62,7 @@ to a stop in NEX/NCF.
             "url": "http://www.cttransit.com"
         }
     ],
-    "application": "GtfsProc 1.8",
+    "application": "GtfsProc 1.8b",
 *   "appuptime_sec": 6,
 *   "dataloadtime_ms": 2830,
     "error": 0,
@@ -109,7 +109,7 @@ to a stop in NEX/NCF.
     "message_type": "NCF",
 *   "proc_time_ms": 10,
     "realtime_age_sec": 10,
-    "static_data_modif": "22-May-2020 22:33:47 EDT",
+*   "static_data_modif": "22-May-2020 22:33:47 EDT",
     "stop_desc": "58",
     "stop_id": "58",
     "stop_name": "Central Row and O S H",
@@ -190,7 +190,7 @@ to a stop in NEX/NCF.
     "message_type": "NCF",
 *   "proc_time_ms": 2,
     "realtime_age_sec": 10,
-    "static_data_modif": "22-May-2020 22:33:47 EDT",
+*   "static_data_modif": "22-May-2020 22:33:47 EDT",
     "stop_desc": "88",
     "stop_id": "88",
     "stop_name": "W Center St and McKee St",
@@ -204,7 +204,7 @@ to a stop in NEX/NCF.
             "realtime_data": {
                 "actual_arrival": "",
                 "actual_departure": "",
-*               "offset_seconds": 94622715952752,
+                "offset_seconds": 0,
                 "status": "SKIP",
                 "stop_status": "",
                 "vehicle": ""

--- a/tests/CTTransit/trips_before_and_after_midnight.test
+++ b/tests/CTTransit/trips_before_and_after_midnight.test
@@ -59,7 +59,7 @@ case proves that both types of trips are visible to a single stop that is served
             "url": "http://www.cttransit.com"
         }
     ],
-    "application": "GtfsProc 1.8",
+    "application": "GtfsProc 1.8b",
 *   "appuptime_sec": 16,
 *   "dataloadtime_ms": 2736,
     "error": 0,
@@ -106,7 +106,7 @@ case proves that both types of trips are visible to a single stop that is served
     "message_type": "NCF",
 *   "proc_time_ms": *****,
     "realtime_age_sec": 26,
-    "static_data_modif": "22-May-2020 22:33:47 EDT",
+*   "static_data_modif": "22-May-2020 22:33:47 EDT",
     "stop_desc": "6671",
     "stop_id": "6671",
     "stop_name": "Atlantic St and N State St",

--- a/tests/MBTA/after_midnights.test
+++ b/tests/MBTA/after_midnights.test
@@ -30,7 +30,7 @@ and canceled).
             "url": "http://www.mbta.com"
         }
     ],
-    "application": "GtfsProc 1.8",
+    "application": "GtfsProc 1.8b",
 *   "appuptime_sec": 15,
 *   "dataloadtime_ms": 8034,
     "error": 0,
@@ -77,7 +77,7 @@ and canceled).
     "message_type": "NCF",
 *   "proc_time_ms": *****,
     "realtime_age_sec": 20,
-    "static_data_modif": "22-May-2020 22:33:47 EDT",
+*   "static_data_modif": "22-May-2020 22:33:47 EDT",
     "stop_desc": "",
     "stop_id": "2037",
     "stop_name": "Mt Auburn St @ Winsor Ave",
@@ -184,7 +184,7 @@ and canceled).
     "message_type": "NCF",
 *   "proc_time_ms": *****,
     "realtime_age_sec": 20,
-    "static_data_modif": "22-May-2020 22:33:47 EDT",
+*   "static_data_modif": "22-May-2020 22:33:47 EDT",
     "stop_desc": "Suffolk Downs - Blue Line - Wonderland",
     "stop_id": "70054",
     "stop_name": "Suffolk Downs",
@@ -198,7 +198,7 @@ and canceled).
             "realtime_data": {
                 "actual_arrival": "",
                 "actual_departure": "",
-*               "offset_seconds": 94133527606816,
+                "offset_seconds": 0,
                 "status": "CNCL",
                 "stop_status": "",
                 "vehicle": ""
@@ -244,7 +244,7 @@ and canceled).
     "message_type": "NCF",
 *   "proc_time_ms": *****,
     "realtime_age_sec": 20,
-    "static_data_modif": "22-May-2020 22:33:47 EDT",
+*   "static_data_modif": "22-May-2020 22:33:47 EDT",
     "stop_desc": "Airport - Blue Line - Bowdoin",
     "stop_id": "70047",
     "stop_name": "Airport",

--- a/tests/RIPTA/trips_midnight_extrapolation.test
+++ b/tests/RIPTA/trips_midnight_extrapolation.test
@@ -27,7 +27,7 @@ offset prediction in a trip can be extrapolated from the last known offset.
             "url": "http://www.ripta.com/"
         }
     ],
-    "application": "GtfsProc 1.8",
+    "application": "GtfsProc 1.8b",
 *   "appuptime_sec": 57,
 *   "dataloadtime_ms": 807,
     "error": 0,
@@ -74,7 +74,7 @@ offset prediction in a trip can be extrapolated from the last known offset.
     "message_type": "NCF",
 *   "proc_time_ms": *****,
     "realtime_age_sec": 15,
-    "static_data_modif": "22-May-2020 22:33:48 EDT",
+*   "static_data_modif": "22-May-2020 22:33:48 EDT",
     "stop_desc": "",
     "stop_id": "72010",
     "stop_name": "PROVIDENCE STATION",

--- a/tests/SEPTA_Rail/trips_before_and_after_midnight.test
+++ b/tests/SEPTA_Rail/trips_before_and_after_midnight.test
@@ -28,7 +28,7 @@ published with an offset, the remaining stops in a trip are assumed to have the 
             "url": "http://www.septa.org"
         }
     ],
-    "application": "GtfsProc 1.8",
+    "application": "GtfsProc 1.8b",
 *   "appuptime_sec": 9,
 *   "dataloadtime_ms": 8,
     "error": 0,
@@ -75,7 +75,7 @@ published with an offset, the remaining stops in a trip are assumed to have the 
     "message_type": "NCF",
 *   "proc_time_ms": *****,
     "realtime_age_sec": 28,
-    "static_data_modif": "22-May-2020 22:33:48 EDT",
+*   "static_data_modif": "22-May-2020 22:33:48 EDT",
     "stop_desc": "Parent Station",
     "stop_id": "90530",
     "stop_name": "Pennbrook",
@@ -114,7 +114,7 @@ published with an offset, the remaining stops in a trip are assumed to have the 
     "message_type": "NCF",
 *   "proc_time_ms": *****,
     "realtime_age_sec": 28,
-    "static_data_modif": "22-May-2020 22:33:48 EDT",
+*   "static_data_modif": "22-May-2020 22:33:48 EDT",
     "stop_desc": "Parent Station",
     "stop_id": "90521",
     "stop_name": "Merion",


### PR DESCRIPTION
Makes the non-regression environment able to take a single test file.
Updates all copyrights to 2018-2021.
Fixes compilation warnings for Qt 5.15.
Fixes the bug wherein trips skipping a stop or altogether canceled end up getting assigned an offset in seconds that made no sense (uninitialized data).