### PR TITLE
Version 1.8c - Revert Qt 5.15 warning fixes

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,5 +1,11 @@
-THIS RELEASE: Version 1.8b Features and Fixes:
-----------------------------------------------
+THIS RELEASE: Version 1.8c Fixes
+--------------------------------
+- Revert the endl/Qt::endl/noforcesign change for Qt 5.15, it is incompatible with Qt 5.12 which
+  Debian stable uses
+
+PREVIOUS RELEASES:
+Version 1.8b Features and Fixes
+-------------------------------
 - Update copyright dates
 - Added non-regression test suite
 - Canceled trips should not return garbage numbers for schedule offset
@@ -7,8 +13,6 @@ THIS RELEASE: Version 1.8b Features and Fixes:
 - Cleanup some dead code
 - Actually increment version number this time
 
-
-PREVIOUS RELEASES:
 Version 1.8a Features and Fixes
 -------------------------------
 - Do not force check of stop ID for real-time integration if the -q option is not used, the sequence match

--- a/client_cli/clientgtfs.cpp
+++ b/client_cli/clientgtfs.cpp
@@ -178,7 +178,7 @@ void ClientGtfs::repl()
             screen << "GTFS Server Status"
                    << qSetFieldWidth(this->disp.getCols() - 18)      // 18 == "GTFS Server Status".length()
                    << respObj["message_time"].toString()
-                   << qSetFieldWidth(0) << Qt::endl << Qt::endl;
+                   << qSetFieldWidth(0) << endl << endl;
 
             // Easier to understand uptime
             qint64 uptimeMs = respObj["appuptime_ms"].toInt();
@@ -187,33 +187,33 @@ void ClientGtfs::repl()
             qint8  mins     = (uptimeMs - days * 86400000 - hours * 3600000) / 60000;
             qint8  secs     = (uptimeMs - days * 86400000 - hours * 3600000 - mins * 60000) / 1000;
 
-            screen << "[ Backend ]" << Qt::endl;
-            screen << "Processed Reqs . . " << respObj["processed_reqs"].toInt() << Qt::endl;
+            screen << "[ Backend ]" << endl;
+            screen << "Processed Reqs . . " << respObj["processed_reqs"].toInt() << endl;
             screen << "Uptime . . . . . . " << days  << "d " << qSetFieldWidth(2)
                                             << hours << "h "
                                             << mins  << "m "
-                                            << secs  << "s " << qSetFieldWidth(0) << Qt::endl;
-            screen << "Data Load Time . . " << respObj["dataloadtime_ms"].toInt() << "ms" << Qt::endl;
-            screen << "Thread Pool  . . . " << respObj["threadpool_count"].toInt() << Qt::endl;
-            screen << "System Version . . " << respObj["application"].toString() << Qt::endl << Qt::endl;
+                                            << secs  << "s " << qSetFieldWidth(0) << endl;
+            screen << "Data Load Time . . " << respObj["dataloadtime_ms"].toInt() << "ms" << endl;
+            screen << "Thread Pool  . . . " << respObj["threadpool_count"].toInt() << endl;
+            screen << "System Version . . " << respObj["application"].toString() << endl << endl;
 
-            screen << "[ Static Feed Information ]" << Qt::endl;
-            screen << "Publisher  . . . . " << respObj["feed_publisher"].toString() << Qt::endl;
-            screen << "URL  . . . . . . . " << respObj["feed_url"].toString() << Qt::endl;
-            screen << "Language . . . . . " << respObj["feed_lang"].toString() << Qt::endl;
+            screen << "[ Static Feed Information ]" << endl;
+            screen << "Publisher  . . . . " << respObj["feed_publisher"].toString() << endl;
+            screen << "URL  . . . . . . . " << respObj["feed_url"].toString() << endl;
+            screen << "Language . . . . . " << respObj["feed_lang"].toString() << endl;
             screen << "Valid Time . . . . " << "Start: " << respObj["feed_valid_start"].toString() << ", End: "
-                                            << respObj["feed_valid_end"].toString() << Qt::endl;
-            screen << "Version Text . . . " << respObj["feed_version"].toString() << Qt::endl;
-            screen << "Recs Loaded  . . . " << respObj["records"].toInt() << Qt::endl;
-            screen << Qt::endl;
+                                            << respObj["feed_valid_end"].toString() << endl;
+            screen << "Version Text . . . " << respObj["feed_version"].toString() << endl;
+            screen << "Recs Loaded  . . . " << respObj["records"].toInt() << endl;
+            screen << endl;
 
-            screen << "[ Agency Load ]" << Qt::endl;
+            screen << "[ Agency Load ]" << endl;
 
             screen.setFieldAlignment(QTextStream::AlignLeft);
             screen << qSetFieldWidth(c1) << "ID"        << qSetFieldWidth(1) << " "
                    << qSetFieldWidth(c2) << "NAME"      << qSetFieldWidth(1) << " "
                    << qSetFieldWidth(c3) << "TIMEZONE"  << qSetFieldWidth(1) << " "
-                   << qSetFieldWidth(c4) << "PHONE"     << qSetFieldWidth(0) << Qt::endl;
+                   << qSetFieldWidth(c4) << "PHONE"     << qSetFieldWidth(0) << endl;
 
             QJsonArray agencies = respObj["agencies"].toArray();
             for (const QJsonValue ag : agencies) {
@@ -221,10 +221,10 @@ void ClientGtfs::repl()
                        << qSetFieldWidth(c2) << ag["name"].toString().left(c2) << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c3) << ag["tz"].toString().left(c3)   << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c4) << ag["phone"].toString().left(c4)
-                       << qSetFieldWidth( 0) << Qt::endl;
+                       << qSetFieldWidth( 0) << endl;
             }
             screen.setFieldAlignment(QTextStream::AlignRight);
-            screen << Qt::endl;
+            screen << endl;
         }
 
         /*
@@ -245,17 +245,17 @@ void ClientGtfs::repl()
             screen << "Route List"
                    << qSetFieldWidth(this->disp.getCols() - 10)      // 10 == "Route List".length()
                    << respObj["message_time"].toString()
-                   << qSetFieldWidth(0) << Qt::endl << Qt::endl;
+                   << qSetFieldWidth(0) << endl << endl;
 
             // Useful data?
-            screen << "Query took " << respObj["proc_time_ms"].toInt() << " ms" << Qt::endl << Qt::endl;
+            screen << "Query took " << respObj["proc_time_ms"].toInt() << " ms" << endl << endl;
 
             // Start spitting out the routes
             screen.setFieldAlignment(QTextStream::AlignLeft);
             screen << qSetFieldWidth(c1) << "ID"         << qSetFieldWidth(1) << " "
                    << qSetFieldWidth(c2) << "SHORT NAME" << qSetFieldWidth(1) << " "
                    << qSetFieldWidth(c3) << "LONG NAME"  << qSetFieldWidth(1) << " "
-                   << qSetFieldWidth(c4) << "TRIPS"      << qSetFieldWidth(0) << Qt::endl;
+                   << qSetFieldWidth(c4) << "TRIPS"      << qSetFieldWidth(0) << endl;
 
             QJsonArray routes = respObj["routes"].toArray();
             for (const QJsonValue ro : routes) {
@@ -263,11 +263,11 @@ void ClientGtfs::repl()
                        << qSetFieldWidth(c2) << ro["short_name"].toString().left(c2) << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c3) << ro["long_name"].toString().left(c3)  << qSetFieldWidth(1) << " ";
                 screen.setFieldAlignment(QTextStream::AlignRight);
-                screen << qSetFieldWidth(c4) << ro["nb_trips"].toInt()               << qSetFieldWidth(0) << Qt::endl;
+                screen << qSetFieldWidth(c4) << ro["nb_trips"].toInt()               << qSetFieldWidth(0) << endl;
                 screen.setFieldAlignment(QTextStream::AlignLeft);
             }
 
-            screen << Qt::endl;
+            screen << endl;
             screen.setFieldAlignment(QTextStream::AlignRight);
         }
 
@@ -291,37 +291,37 @@ void ClientGtfs::repl()
             screen << "Trip Schedule"
                    << qSetFieldWidth(this->disp.getCols() - 13)
                    << respObj["message_time"].toString()
-                   << qSetFieldWidth(0) << Qt::endl << Qt::endl;
+                   << qSetFieldWidth(0) << endl << endl;
 
             if (respObj["error"].toInt() == 101) {
-                screen << "Trip not found in static database." << Qt::endl;
+                screen << "Trip not found in static database." << endl;
             } else if (respObj["error"].toInt() == 102) {
-                screen << "Trip not found in real-time data feed." << Qt::endl;
+                screen << "Trip not found in real-time data feed." << endl;
             } else {
                 bool realTimeData = respObj["real_time"].toBool();
 
-                screen << "Trip ID  . . . . . " << respObj["trip_id"].toString() << Qt::endl;
+                screen << "Trip ID  . . . . . " << respObj["trip_id"].toString() << endl;
                 if (!realTimeData) {
-                    screen << "Service ID . . . . " << respObj["service_id"].toString() << Qt::endl;
+                    screen << "Service ID . . . . " << respObj["service_id"].toString() << endl;
                     screen << "Validity . . . . . " << respObj["svc_start_date"].toString() << " - "
-                                                    << respObj["svc_end_date"].toString() << Qt::endl;
-                    screen << "Operating Days . . " << respObj["operate_days"].toString() << Qt::endl;
-                    screen << "Exceptions . . . . " << respObj["exception_dates"].toString() << Qt::endl;
-                    screen << "Additions  . . . . " << respObj["added_dates"].toString() << Qt::endl;
+                                                    << respObj["svc_end_date"].toString() << endl;
+                    screen << "Operating Days . . " << respObj["operate_days"].toString() << endl;
+                    screen << "Exceptions . . . . " << respObj["exception_dates"].toString() << endl;
+                    screen << "Additions  . . . . " << respObj["added_dates"].toString() << endl;
                 }
-                screen << "Route ID . . . . . " << respObj["route_id"].toString() << Qt::endl;
+                screen << "Route ID . . . . . " << respObj["route_id"].toString() << endl;
                 screen << "Route Name . . . . " << respObj["route_short_name"].toString() << ", \""
-                                                << respObj["route_long_name"].toString()  << "\"" << Qt::endl;
+                                                << respObj["route_long_name"].toString()  << "\"" << endl;
                 if (!realTimeData) {
-                    screen << "Headsign . . . . . " << respObj["headsign"].toString() << Qt::endl;
+                    screen << "Headsign . . . . . " << respObj["headsign"].toString() << endl;
                 } else {
-                    screen << "Vehicle  . . . . . " << respObj["vehicle"].toString() << Qt::endl;
+                    screen << "Vehicle  . . . . . " << respObj["vehicle"].toString() << endl;
                     screen << "Start Date&Time  . " << respObj["start_date"].toString() << " "
-                                                    << respObj["start_time"].toString() << Qt::endl;
-                    screen << "Real Time Data . . " << respObj["real_time_data_time"].toString() << Qt::endl;
+                                                    << respObj["start_time"].toString() << endl;
+                    screen << "Real Time Data . . " << respObj["real_time_data_time"].toString() << endl;
                 }
 
-                screen << "Short Name . . . . " << respObj["short_name"].toString() << Qt::endl << Qt::endl;
+                screen << "Short Name . . . . " << respObj["short_name"].toString() << endl << endl;
 
                 screen.setFieldAlignment(QTextStream::AlignLeft);
                 screen << qSetFieldWidth(c1)   << "SEQ"       << qSetFieldWidth(1) << " "
@@ -331,11 +331,11 @@ void ClientGtfs::repl()
                 if (!realTimeData) {
                     screen << qSetFieldWidth(c4*2) << "PD"        << qSetFieldWidth(1) << " "
                            << qSetFieldWidth(c5)   << "SCH-A"     << qSetFieldWidth(1) << " "
-                           << qSetFieldWidth(c6)   << "SCH-D"     << qSetFieldWidth(0) << Qt::endl;
+                           << qSetFieldWidth(c6)   << "SCH-D"     << qSetFieldWidth(0) << endl;
                 } else {
                     screen << qSetFieldWidth(c4*2) << "  "        << qSetFieldWidth(1) << " "
                            << qSetFieldWidth(c5)   << "PRE-A"     << qSetFieldWidth(1) << " "
-                           << qSetFieldWidth(c6)   << "PRE-D"     << qSetFieldWidth(0) << Qt::endl;
+                           << qSetFieldWidth(c6)   << "PRE-D"     << qSetFieldWidth(0) << endl;
                 }
 
                 QJsonArray stops = respObj["stops"].toArray();
@@ -349,11 +349,11 @@ void ClientGtfs::repl()
                            << qSetFieldWidth(c4) << pickUp << dropOff                   << qSetFieldWidth(1) << " ";
                     screen.setFieldAlignment(QTextStream::AlignRight);
                     screen << qSetFieldWidth(c5) << st["arr_time"].toString() << qSetFieldWidth(1) << " "
-                           << qSetFieldWidth(c6) << st["dep_time"].toString() << qSetFieldWidth(0) << Qt::endl;
+                           << qSetFieldWidth(c6) << st["dep_time"].toString() << qSetFieldWidth(0) << endl;
                     screen.setFieldAlignment(QTextStream::AlignLeft);
                 }
             }
-            screen << Qt::endl;
+            screen << endl;
             screen.setFieldAlignment(QTextStream::AlignRight);
         }
 
@@ -377,16 +377,16 @@ void ClientGtfs::repl()
             screen << "Trips Serving Route"
                    << qSetFieldWidth(this->disp.getCols() - 19)
                    << respObj["message_time"].toString()
-                   << qSetFieldWidth(0) << Qt::endl << Qt::endl;
+                   << qSetFieldWidth(0) << endl << endl;
 
             if (respObj["error"].toInt() == 201) {
-                screen << "Route not found." << Qt::endl;
+                screen << "Route not found." << endl;
             }
             else {
-                screen << "Route ID . . . . . " << respObj["route_id"].toString() << Qt::endl;
+                screen << "Route ID . . . . . " << respObj["route_id"].toString() << endl;
                 screen << "Route Name . . . . " << respObj["route_short_name"].toString() << ", \""
-                                                << respObj["route_long_name"].toString()  << "\"" << Qt::endl;
-                screen << "Service Date . . . " << respObj["service_date"].toString() << Qt::endl << Qt::endl;
+                                                << respObj["route_long_name"].toString()  << "\"" << endl;
+                screen << "Service Date . . . " << respObj["service_date"].toString() << endl << endl;
 
                 // Loop on all the trips
                 screen.setFieldAlignment(QTextStream::AlignLeft);
@@ -395,7 +395,7 @@ void ClientGtfs::repl()
                        << qSetFieldWidth(c3*2+1) << "VALID-DURATION" << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c4)     << "OPERATING-DAYS" << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c5*2)   << "ES"             << qSetFieldWidth(1) << " "
-                       << qSetFieldWidth(c6)     << "SCH-D"          << qSetFieldWidth(0) << Qt::endl;
+                       << qSetFieldWidth(c6)     << "SCH-D"          << qSetFieldWidth(0) << endl;
 
                 QJsonArray trips = respObj["trips"].toArray();
                 for (const QJsonValue tr : trips) {
@@ -412,15 +412,15 @@ void ClientGtfs::repl()
                            << qSetFieldWidth(1) << dstOn;
                     screen.setFieldAlignment(QTextStream::AlignRight);
                     screen << qSetFieldWidth(c6) << tr["first_stop_departure"].toString()
-                           << qSetFieldWidth(0) << Qt::endl;
+                           << qSetFieldWidth(0) << endl;
                     screen.setFieldAlignment(QTextStream::AlignLeft);
                 }
 
-                screen << Qt::endl << "Query took " << respObj["proc_time_ms"].toInt() << " ms, "
-                       << trips.size() << " records loaded" << Qt::endl;
+                screen << endl << "Query took " << respObj["proc_time_ms"].toInt() << " ms, "
+                       << trips.size() << " records loaded" << endl;
             }
 
-            screen << Qt::endl;
+            screen << endl;
             screen.setFieldAlignment(QTextStream::AlignRight);
         }
 
@@ -445,20 +445,20 @@ void ClientGtfs::repl()
             screen << "Trips Serving Stop"
                    << qSetFieldWidth(this->disp.getCols() - 18)
                    << respObj["message_time"].toString()
-                   << qSetFieldWidth(0) << Qt::endl << Qt::endl;
+                   << qSetFieldWidth(0) << endl << endl;
 
             if (respObj["error"].toInt() == 301) {
-                screen << "Stop not found." << Qt::endl;
+                screen << "Stop not found." << endl;
             }
             else {
                 // Count how many records were returned
                 qint32 tripsLoaded = 0;
 
-                screen << "Stop ID  . . . . . " << respObj["stop_id"].toString() << Qt::endl
-                       << "Stop Name  . . . . " << respObj["stop_name"].toString() << Qt::endl
-                       << "Stop Desc  . . . . " << respObj["stop_desc"].toString() << Qt::endl
-                       << "Parent Station . . " << respObj["parent_sta"].toString() << Qt::endl
-                       << "Service Date . . . " << respObj["service_date"].toString() << Qt::endl << Qt::endl;
+                screen << "Stop ID  . . . . . " << respObj["stop_id"].toString() << endl
+                       << "Stop Name  . . . . " << respObj["stop_name"].toString() << endl
+                       << "Stop Desc  . . . . " << respObj["stop_desc"].toString() << endl
+                       << "Parent Station . . " << respObj["parent_sta"].toString() << endl
+                       << "Service Date . . . " << respObj["service_date"].toString() << endl << endl;
 
                 // ... then all the trips within each route
                 screen.setFieldAlignment(QTextStream::AlignLeft);
@@ -468,14 +468,14 @@ void ClientGtfs::repl()
                        << qSetFieldWidth(c4*2+1) << "VALID-DURATION" << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c5)     << "OPERATING-DAYS" << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c6*5)   << "ES TPD"         << qSetFieldWidth(1) << " "
-                       << qSetFieldWidth(c7)     << "SCH-D"          << qSetFieldWidth(0) << Qt::endl << Qt::endl;
+                       << qSetFieldWidth(c7)     << "SCH-D"          << qSetFieldWidth(0) << endl << endl;
 
                 // Loop on all the routes
                 QJsonArray routes = respObj["routes"].toArray();
                 for (const QJsonValue ro : routes) {
                     screen << "[ Route ID " << ro["route_id"].toString() << " :: "
                                             << ro["route_short_name"].toString() << " :: "
-                                            << ro["route_long_name"].toString()  << " ]"   << Qt::endl;
+                                            << ro["route_long_name"].toString()  << " ]"   << endl;
 
                     // Loop on all the trips
                     QJsonArray trips = ro["trips"].toArray();
@@ -512,18 +512,18 @@ void ClientGtfs::repl()
                                << qSetFieldWidth(c6) << svcExempt << svcSplmnt << " " << tripTerm << pickUp << dropOff
                                << qSetFieldWidth(1) << dstIndic;
                         screen.setFieldAlignment(QTextStream::AlignRight);
-                        screen << qSetFieldWidth(c7) << tr["dep_time"].toString() << qSetFieldWidth(0) << Qt::endl;
+                        screen << qSetFieldWidth(c7) << tr["dep_time"].toString() << qSetFieldWidth(0) << endl;
                         screen.setFieldAlignment(QTextStream::AlignLeft);
                     } // End loop on Trips-within-Route
                     tripsLoaded += trips.size();
-                    screen << Qt::endl;
+                    screen << endl;
                 } // End loop on Routes-serving-Stop
 
                 screen << "Query took " << respObj["proc_time_ms"].toInt() << " ms, "
-                       << tripsLoaded << " trips loaded" << Qt::endl;
+                       << tripsLoaded << " trips loaded" << endl;
             }
 
-            screen << Qt::endl;
+            screen << endl;
             screen.setFieldAlignment(QTextStream::AlignRight);
         }
 
@@ -544,25 +544,25 @@ void ClientGtfs::repl()
             screen << "Individual Stop Service Information"
                    << qSetFieldWidth(this->disp.getCols() - 35)
                    << respObj["message_time"].toString()
-                   << qSetFieldWidth(0) << Qt::endl << Qt::endl;
+                   << qSetFieldWidth(0) << endl << endl;
 
             if (respObj["error"].toInt() == 401) {
-                screen << "Stop not found." << Qt::endl;
+                screen << "Stop not found." << endl;
             }
             else {
                 screen << "Stop ID/Name . . . " << respObj["stop_id"].toString() << " :: "
-                                                << respObj["stop_name"].toString() << Qt::endl;
-                screen << "Stop Desc  . . . . " << respObj["stop_desc"].toString() << Qt::endl;
+                                                << respObj["stop_name"].toString() << endl;
+                screen << "Stop Desc  . . . . " << respObj["stop_desc"].toString() << endl;
                 screen << "Location . . . . . " << respObj["loc_lat"].toString() << ", "
-                                                << respObj["loc_lon"].toString() << Qt::endl;
-                screen << "Parent Station . . " << respObj["parent_sta"].toString() << Qt::endl << Qt::endl;
+                                                << respObj["loc_lon"].toString() << endl;
+                screen << "Parent Station . . " << respObj["parent_sta"].toString() << endl << endl;
 
                 // Show all the Routes associated with the station requested
                 screen.setFieldAlignment(QTextStream::AlignLeft);
-                screen << "[ Routes Serving Stop ]" << Qt::endl;
+                screen << "[ Routes Serving Stop ]" << endl;
                 screen << qSetFieldWidth(c1) << "ROUTE-ID"         << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c2) << "ROUTE-NAME-SHORT" << qSetFieldWidth(1) << " "
-                       << qSetFieldWidth(c3) << "ROUTE-NAME-LONG"  << qSetFieldWidth(1) << Qt::endl;
+                       << qSetFieldWidth(c3) << "ROUTE-NAME-LONG"  << qSetFieldWidth(1) << endl;
 
                 // Loop on all the routes
                 QJsonArray routes = respObj["routes"].toArray();
@@ -572,29 +572,29 @@ void ClientGtfs::repl()
                            << qSetFieldWidth(c2) << ro["route_short_name"].toString().left(c2)
                            << qSetFieldWidth(1) << " "
                            << qSetFieldWidth(c3) << ro["route_long_name"].toString().left(c3)
-                           << qSetFieldWidth(0) << Qt::endl;
+                           << qSetFieldWidth(0) << endl;
                 }
-                screen << Qt::endl;
+                screen << endl;
 
                 // Then display any associated stations with the parent
                 screen.setFieldAlignment(QTextStream::AlignLeft);
-                screen << "[ Stops Sharing Parent Station ]" << Qt::endl;
+                screen << "[ Stops Sharing Parent Station ]" << endl;
                 screen << qSetFieldWidth(c1) << "STOP-ID"   << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c2) << "STOP-NAME" << qSetFieldWidth(1) << " "
-                       << qSetFieldWidth(c3) << "STOP-DESC" << qSetFieldWidth(1) << Qt::endl;
+                       << qSetFieldWidth(c3) << "STOP-DESC" << qSetFieldWidth(1) << endl;
 
                 QJsonArray sharedStops = respObj["stops_sharing_parent"].toArray();
                 for (const QJsonValue ss : sharedStops) {
                     screen << qSetFieldWidth(c1) << ss["stop_id"].toString().left(c1)   << qSetFieldWidth(1) << " "
                            << qSetFieldWidth(c2) << ss["stop_name"].toString().left(c2) << qSetFieldWidth(1) << " "
                            << qSetFieldWidth(c3) << ss["stop_desc"].toString().left(c3)
-                           << qSetFieldWidth(0)  << Qt::endl;
+                           << qSetFieldWidth(0)  << endl;
                 }
-                screen << Qt::endl;
-                screen << "Query took " << respObj["proc_time_ms"].toInt() << " ms" << Qt::endl;
+                screen << endl;
+                screen << "Query took " << respObj["proc_time_ms"].toInt() << " ms" << endl;
             }
 
-            screen << Qt::endl;
+            screen << endl;
             screen.setFieldAlignment(QTextStream::AlignRight);
         }
 
@@ -617,29 +617,29 @@ void ClientGtfs::repl()
             screen << "Route Summary and Stop Information"
                    << qSetFieldWidth(this->disp.getCols() - 34)
                    << respObj["message_time"].toString()
-                   << qSetFieldWidth(0) << Qt::endl << Qt::endl;
+                   << qSetFieldWidth(0) << endl << endl;
 
             if (respObj["error"].toInt() == 501) {
-                screen << "Route not found." << Qt::endl;
+                screen << "Route not found." << endl;
             }
             else {
-                screen << "Route ID . . . . . " << respObj["route_id"].toString() << Qt::endl
-                       << "Short Name . . . . " << respObj["route_short_name"].toString() << Qt::endl
-                       << "Long Name  . . . . " << respObj["route_long_name"].toString() << Qt::endl
-                       << "Description  . . . " << respObj["route_desc"].toString() << Qt::endl
-                       << "Type . . . . . . . " << respObj["route_type"].toString() << Qt::endl
-                       << "URL  . . . . . . . " << respObj["route_url"].toString() << Qt::endl
-                       << "Color  . . . . . . " << respObj["route_color"].toString() << Qt::endl
-                       << "Text Color . . . . " << respObj["route_text_color"].toString() << Qt::endl << Qt::endl;
+                screen << "Route ID . . . . . " << respObj["route_id"].toString() << endl
+                       << "Short Name . . . . " << respObj["route_short_name"].toString() << endl
+                       << "Long Name  . . . . " << respObj["route_long_name"].toString() << endl
+                       << "Description  . . . " << respObj["route_desc"].toString() << endl
+                       << "Type . . . . . . . " << respObj["route_type"].toString() << endl
+                       << "URL  . . . . . . . " << respObj["route_url"].toString() << endl
+                       << "Color  . . . . . . " << respObj["route_color"].toString() << endl
+                       << "Text Color . . . . " << respObj["route_text_color"].toString() << endl << endl;
 
                 // Show all the Routes associated with the station requested
                 screen.setFieldAlignment(QTextStream::AlignLeft);
-                screen << "[ Stops Served by Route ]" << Qt::endl;
+                screen << "[ Stops Served by Route ]" << endl;
                 screen << qSetFieldWidth(c1)     << "STOP-ID"   << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c2)     << "STOP-NAME" << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c3)     << "STOP-DESC" << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c4)     << "#TRIPS"    << qSetFieldWidth(1) << " "
-                       << qSetFieldWidth(c5 * 2) << "LOCATION"  << qSetFieldWidth(1) << Qt::endl;
+                       << qSetFieldWidth(c5 * 2) << "LOCATION"  << qSetFieldWidth(1) << endl;
 
                 // Loop on all the routes
                 QJsonArray stops = respObj["stops"].toArray();
@@ -651,10 +651,10 @@ void ClientGtfs::repl()
                     screen << qSetFieldWidth(c4) << so["trip_count"].toInt()            << qSetFieldWidth(1) << " "
                            << qSetFieldWidth(c5) << so["stop_lat"].toString().left(c5)  << qSetFieldWidth(1) << ","
                            << qSetFieldWidth(c5) << so["stop_lon"].toString().left(c5)
-                           << qSetFieldWidth(0)  << Qt::endl;
+                           << qSetFieldWidth(0)  << endl;
                     screen.setFieldAlignment(QTextStream::AlignLeft);
                 }
-                screen << Qt::endl;
+                screen << endl;
             }
             screen.setFieldAlignment(QTextStream::AlignRight);
         }
@@ -680,18 +680,18 @@ void ClientGtfs::repl()
             screen << "Upcoming Service at Stop"
                    << qSetFieldWidth(this->disp.getCols() - 24)
                    << respObj["message_time"].toString()
-                   << qSetFieldWidth(0) << Qt::endl << Qt::endl;
+                   << qSetFieldWidth(0) << endl << endl;
 
             if (respObj["error"].toInt() == 601) {
-                screen << "Stop not found." << Qt::endl;
+                screen << "Stop not found." << endl;
             }
             else {
                 // Count how many records were returned
                 qint32 tripsLoaded = 0;
 
-                screen << "Stop ID  . . . . . " << respObj["stop_id"].toString()   << Qt::endl
-                       << "Stop Name  . . . . " << respObj["stop_name"].toString() << Qt::endl
-                       << "Stop Desc  . . . . " << respObj["stop_desc"].toString() << Qt::endl << Qt::endl;
+                screen << "Stop ID  . . . . . " << respObj["stop_id"].toString()   << endl
+                       << "Stop Name  . . . . " << respObj["stop_name"].toString() << endl
+                       << "Stop Desc  . . . . " << respObj["stop_desc"].toString() << endl << endl;
 
                 // ... then all the trips within each route
                 screen.setFieldAlignment(QTextStream::AlignLeft);
@@ -701,12 +701,12 @@ void ClientGtfs::repl()
                        << qSetFieldWidth(c4*3) << "TPD"       << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c5)   << "STOP-TIME" << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c6)   << "MINS"      << qSetFieldWidth(1) << " "
-                       << qSetFieldWidth(c7)   << "STAT"      << qSetFieldWidth(0) << Qt::endl;
+                       << qSetFieldWidth(c7)   << "STAT"      << qSetFieldWidth(0) << endl;
 
                 // Loop on all the routes
                 QJsonArray routes = respObj["routes"].toArray();
                 for (const QJsonValue ro : routes) {
-                    screen << "[ Route ID " << ro["route_id"].toString() << " ]"   << Qt::endl;
+                    screen << "[ Route ID " << ro["route_id"].toString() << " ]"   << endl;
 
                     // Loop on all the trips
                     QJsonArray trips = ro["trips"].toArray();
@@ -794,7 +794,7 @@ void ClientGtfs::repl()
                                     if (offsetSec < -60 || offsetSec > 60) {
                                         screen.setNumberFlags(QTextStream::ForceSign);
                                         screen << qSetFieldWidth(c7) << offsetSec / 60 << qSetFieldWidth(0);
-                                        Qt::noforcesign(screen);
+                                        noforcesign(screen);
                                     } else {
                                         screen << qSetFieldWidth(c7) << "ONTM" << qSetFieldWidth(0);
                                     }
@@ -815,19 +815,19 @@ void ClientGtfs::repl()
                         }
 
                         screen.setFieldAlignment(QTextStream::AlignLeft);
-                        screen << Qt::endl;
+                        screen << endl;
 
                     } // End loop on Trips-within-Route
 
                     tripsLoaded += trips.size();
-                    screen << Qt::endl;
+                    screen << endl;
                 } // End loop on Routes-serving-Stop
 
                 screen << "Query took " << respObj["proc_time_ms"].toInt() << " ms, "
-                       << tripsLoaded << " trips loaded" << Qt::endl;
+                       << tripsLoaded << " trips loaded" << endl;
             }
 
-            screen << Qt::endl;
+            screen << endl;
             screen.setFieldAlignment(QTextStream::AlignRight);
         }
 
@@ -853,18 +853,18 @@ void ClientGtfs::repl()
             screen << "Upcoming Service at Stop"
                    << qSetFieldWidth(this->disp.getCols() - 24)
                    << respObj["message_time"].toString()
-                   << qSetFieldWidth(0) << Qt::endl << Qt::endl;
+                   << qSetFieldWidth(0) << endl << endl;
 
             if (respObj["error"].toInt() == 601) {
-                screen << "Stop not found." << Qt::endl;
+                screen << "Stop not found." << endl;
             }
             else {
                 // Count how many records were returned
                 qint32 tripsLoaded = 0;
 
-                screen << "Stop ID  . . . . . " << respObj["stop_id"].toString()   << Qt::endl
-                       << "Stop Name  . . . . " << respObj["stop_name"].toString() << Qt::endl
-                       << "Stop Desc  . . . . " << respObj["stop_desc"].toString() << Qt::endl << Qt::endl;
+                screen << "Stop ID  . . . . . " << respObj["stop_id"].toString()   << endl
+                       << "Stop Name  . . . . " << respObj["stop_name"].toString() << endl
+                       << "Stop Desc  . . . . " << respObj["stop_desc"].toString() << endl << endl;
 
                 // ... then all the trips within each route
                 screen.setFieldAlignment(QTextStream::AlignLeft);
@@ -875,7 +875,7 @@ void ClientGtfs::repl()
                        << qSetFieldWidth(c5*3) << "TPD"       << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c6)   << "STOP-TIME" << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c7)   << "MINS"      << qSetFieldWidth(1) << " "
-                       << qSetFieldWidth(c8)   << "STAT"      << qSetFieldWidth(0) << Qt::endl;
+                       << qSetFieldWidth(c8)   << "STAT"      << qSetFieldWidth(0) << endl;
 
                 // Loop on all the trips
                 QJsonArray trips = respObj["trips"].toArray();
@@ -964,7 +964,7 @@ void ClientGtfs::repl()
                                 if (offsetSec < -60 || offsetSec > 60) {
                                     screen.setNumberFlags(QTextStream::ForceSign);
                                     screen << qSetFieldWidth(c8) << offsetSec / 60 << qSetFieldWidth(0);
-                                    Qt::noforcesign(screen);
+                                    noforcesign(screen);
                                 } else {
                                     screen << qSetFieldWidth(c8) << "ONTM" << qSetFieldWidth(0);
                                 }
@@ -985,18 +985,18 @@ void ClientGtfs::repl()
                     }
 
                     screen.setFieldAlignment(QTextStream::AlignLeft);
-                    screen << Qt::endl;
+                    screen << endl;
 
                 } // End loop on Trips-within-Route
 
                 tripsLoaded += trips.size();
-                screen << Qt::endl;
+                screen << endl;
 
                 screen << "Query took " << respObj["proc_time_ms"].toInt() << " ms, "
-                       << tripsLoaded << " trips loaded" << Qt::endl;
+                       << tripsLoaded << " trips loaded" << endl;
             }
 
-            screen << Qt::endl;
+            screen << endl;
             screen.setFieldAlignment(QTextStream::AlignRight);
         }
 
@@ -1018,13 +1018,13 @@ void ClientGtfs::repl()
             screen << "Stops Without Trips"
                    << qSetFieldWidth(this->disp.getCols() - 19)
                    << respObj["message_time"].toString()
-                   << qSetFieldWidth(0) << Qt::endl << Qt::endl;
+                   << qSetFieldWidth(0) << endl << endl;
 
             screen.setFieldAlignment(QTextStream::AlignLeft);
             screen << qSetFieldWidth(c1) << "STOP-ID"   << qSetFieldWidth(1) << " "
                    << qSetFieldWidth(c2) << "STOP-NAME" << qSetFieldWidth(1) << " "
                    << qSetFieldWidth(c3) << "STOP-DESC" << qSetFieldWidth(1) << " "
-                   << qSetFieldWidth(c4) << "LOCATION"  << qSetFieldWidth(1) << Qt::endl;
+                   << qSetFieldWidth(c4) << "LOCATION"  << qSetFieldWidth(1) << endl;
 
             // Loop on all the routes
             QJsonArray stops = respObj["stops"].toArray();
@@ -1039,10 +1039,10 @@ void ClientGtfs::repl()
                 screen << qSetFieldWidth(c4/2) << st["loc_lat"].toString().left(c4/2)
                        << qSetFieldWidth(1)    << ","
                        << qSetFieldWidth(c4/2) << st["loc_lon"].toString().left(c4/2)
-                       << qSetFieldWidth(0)    << Qt::endl;
+                       << qSetFieldWidth(0)    << endl;
                 screen.setFieldAlignment(QTextStream::AlignLeft);
             }
-            screen << Qt::endl << "Query took " << respObj["proc_time_ms"].toInt() << " ms" << Qt::endl << Qt::endl;
+            screen << endl << "Query took " << respObj["proc_time_ms"].toInt() << " ms" << endl << endl;
             screen.setFieldAlignment(QTextStream::AlignRight);
         }
 
@@ -1062,40 +1062,40 @@ void ClientGtfs::repl()
             screen << "GTFS Realtime Data Status"
                    << qSetFieldWidth(this->disp.getCols() - 25)
                    << respObj["message_time"].toString()
-                   << qSetFieldWidth(0) << Qt::endl << Qt::endl;
+                   << qSetFieldWidth(0) << endl << endl;
 
             screen.setFieldAlignment(QTextStream::AlignLeft);
 
             // Mutual Exclusion
-            screen << "[ Mutual Exclusion ]" << Qt::endl
-                   << "Active Side  . . . " << respObj["active_side"].toString() << Qt::endl
-                   << "Data Age . . . . . " << respObj["active_age_sec"].toInt() << " s" << Qt::endl
-                   << "Feed Time  . . . . " << respObj["active_feed_time"].toString() << Qt::endl
-                   << "Download Time  . . " << respObj["active_download_ms"].toInt() << " ms" << Qt::endl
-                   << "Integ Time . . . . " << respObj["active_integration_ms"].toInt() << " ms" << Qt::endl
-                   << "Next Fetch In  . . " << respObj["seconds_to_next_fetch"].toInt() << " s" << Qt::endl
-                   << "Latest RT Txn  . . " << respObj["last_realtime_query"].toString() << Qt::endl
-                   << Qt::endl << Qt::endl;
+            screen << "[ Mutual Exclusion ]" << endl
+                   << "Active Side  . . . " << respObj["active_side"].toString() << endl
+                   << "Data Age . . . . . " << respObj["active_age_sec"].toInt() << " s" << endl
+                   << "Feed Time  . . . . " << respObj["active_feed_time"].toString() << endl
+                   << "Download Time  . . " << respObj["active_download_ms"].toInt() << " ms" << endl
+                   << "Integ Time . . . . " << respObj["active_integration_ms"].toInt() << " ms" << endl
+                   << "Next Fetch In  . . " << respObj["seconds_to_next_fetch"].toInt() << " s" << endl
+                   << "Latest RT Txn  . . " << respObj["last_realtime_query"].toString() << endl
+                   << endl << endl;
 
 
             screen << qSetFieldWidth(c1) << "TRIP-ID"   << qSetFieldWidth(1) << " "
-                   << qSetFieldWidth(c2) << "ROUTE-ID"  << qSetFieldWidth(1) << Qt::endl;
+                   << qSetFieldWidth(c2) << "ROUTE-ID"  << qSetFieldWidth(1) << endl;
 
             // Loop on all the routes
             //QJsonArray stops = respObj["stops"].toArray();
 
-            screen << Qt::endl << "Query took " << respObj["proc_time_ms"].toInt() << " ms" << Qt::endl << Qt::endl;
+            screen << endl << "Query took " << respObj["proc_time_ms"].toInt() << " ms" << endl << endl;
             screen.setFieldAlignment(QTextStream::AlignRight);
         }
 
         // Probably some kind of error condition, just respond in kind
         else {
-            screen << Qt::endl << "No handler for the request: " << Qt::endl << responseStr << Qt::endl;
+            screen << endl << "No handler for the request: " << endl << responseStr << endl;
         }
     }
 
     // On exit (loop halted above)
-    screen << "*** DISCONNECTING ***" << Qt::endl;
+    screen << "*** DISCONNECTING ***" << endl;
 }
 
 QString ClientGtfs::dropoffToChar(qint8 svcDropOff)

--- a/client_cli/structureddisplay.cpp
+++ b/client_cli/structureddisplay.cpp
@@ -70,42 +70,42 @@ void Display::displayWelcome()
     //
     QTextStream screen(stdout);
     screen << buffer << "GTFS Interactive Data Console -- Version: "
-                     << QCoreApplication::applicationVersion() << Qt::endl
-           << Qt::endl
-           << "[ System Information ]" << Qt::endl
-           << "SDS: Backend system and data load status" << Qt::endl
-           << "RDS: GTFS Real-Time data retrieval status" << Qt::endl
-           << "RTE: Routes available from the data set" << Qt::endl
-           << "SSR: List of all stops served by a single route" << Qt::endl
-           << "SNT: List all stops that have no trips (diagnostic)" << Qt::endl
-           << Qt::endl
-           << "[ Full Schedule Lookup ]" << Qt::endl
-           << "STA: Stop information lookup by stop_id" << Qt::endl
-           << "TSR: List of trips serving a route_id" << Qt::endl
-           << "TSS: List of trips serving a stop_id" << Qt::endl
-           << "TRI: List all the stops served by a trip_id" << Qt::endl
-           << "RTS/RTF/RTT: List the real-time data of an active trip_id or update" << Qt::endl
-           << Qt::endl
-           << "[ Data Lookup for Specific Date ]" << Qt::endl
-           << "TRD: List of trips serving a route_id on a date" << Qt::endl
-           << "TSD: List of trips serving a stop_id on a date" << Qt::endl
-           << "NEX: List upcoming trips serving a stop_id within a number of minutes" << Qt::endl
-           << Qt::endl
+                     << QCoreApplication::applicationVersion() << endl
+           << endl
+           << "[ System Information ]" << endl
+           << "SDS: Backend system and data load status" << endl
+           << "RDS: GTFS Real-Time data retrieval status" << endl
+           << "RTE: Routes available from the data set" << endl
+           << "SSR: List of all stops served by a single route" << endl
+           << "SNT: List all stops that have no trips (diagnostic)" << endl
+           << endl
+           << "[ Full Schedule Lookup ]" << endl
+           << "STA: Stop information lookup by stop_id" << endl
+           << "TSR: List of trips serving a route_id" << endl
+           << "TSS: List of trips serving a stop_id" << endl
+           << "TRI: List all the stops served by a trip_id" << endl
+           << "RTS/RTF/RTT: List the real-time data of an active trip_id or update" << endl
+           << endl
+           << "[ Data Lookup for Specific Date ]" << endl
+           << "TRD: List of trips serving a route_id on a date" << endl
+           << "TSD: List of trips serving a stop_id on a date" << endl
+           << "NEX: List upcoming trips serving a stop_id within a number of minutes" << endl
+           << endl
            << "Reinitialize the display with 'HOM', quit using 'BYE'"
-           << Qt::endl << Qt::endl;
+           << endl << endl;
 }
 
 void Display::showServer(QString hostname, int port)
 {
     QTextStream screen(stdout);
-    screen << "Connected to: " << hostname << " : " << port << Qt::endl;
+    screen << "Connected to: " << hostname << " : " << port << endl;
     screen.flush();
 }
 
 void Display::showError(QString errorText)
 {
     QTextStream screen(stdout);
-    screen << "Error: " << errorText << Qt::endl;
+    screen << "Error: " << errorText << endl;
     screen.flush();
 }
 

--- a/gtfs_process/gtfsstatus.cpp
+++ b/gtfs_process/gtfsstatus.cpp
@@ -131,8 +131,8 @@ Status::Status(const QString dataRootPath,
                          brokenDateParams.at(4).toInt(),
                          brokenDateParams.at(5).toInt());
         frozenAgencyTime = QDateTime(frozenDate, frozenTime, this->serverFeedTZ);
-        qDebug() << Qt::endl << "TESTING/DEBUGGING/ANALYSIS MODE: All transaction will be processed as if it is "
-                 << frozenAgencyTime << Qt::endl;
+        qDebug() << endl << "TESTING/DEBUGGING/ANALYSIS MODE: All transaction will be processed as if it is "
+                 << frozenAgencyTime << endl;
     }
 
     // Show all times with AM/PM indicator instead of standard 24-hour clock

--- a/gtfs_realtime/gtfsrealtimefeed.cpp
+++ b/gtfs_realtime/gtfsrealtimefeed.cpp
@@ -788,9 +788,9 @@ void RealTimeTripUpdate::showProtobufData() const
     google::protobuf::TextFormat::PrintToString(_tripUpdate, &data);
     qDebug() << "GTFS-Realtime : LOCAL DEBUGGING MODE";
     qDebug() << "-----[ CONTENTS ]------------------------------------------------------------------------------------";
-    qDebug() << data.c_str() << Qt::endl
+    qDebug() << data.c_str() << endl
              << "-----------------------------------------------------------------------[ END PROTOBUF CONTENTS ]-----";
-    qDebug() << "Protobuf: " << _tripUpdate.ByteSize() << " bytes" << Qt::endl;
+    qDebug() << "Protobuf: " << _tripUpdate.ByteSize() << " bytes" << endl;
     qDebug() << "Processing _tripUpdate.entity_size() = " << _tripUpdate.entity_size() << "real-time records.";
 }
 

--- a/gtfsproc/servegtfs.cpp
+++ b/gtfsproc/servegtfs.cpp
@@ -106,7 +106,7 @@ ServeGTFS::~ServeGTFS()
 void ServeGTFS::displayDebugging() const
 {
     const GTFS::Status *data = GTFS::DataGateway::inst().getStatus();
-    qDebug() << Qt::endl << "[ GTFS Static Data Information ]";
+    qDebug() << endl << "[ GTFS Static Data Information ]";
     qDebug() << "Recs Loaded . . . ." << data->getRecordsLoaded();
     qDebug() << "Server Start Time ." << data->getServerStartTimeUTC();
     qDebug() << "Feed Publisher  . ." << data->getPublisher();
@@ -114,7 +114,7 @@ void ServeGTFS::displayDebugging() const
     qDebug() << "Feed Language . . ." << data->getLanguage();
     qDebug() << "Feed Start Date . ." << data->getStartDate().toString("dd-MMM-yyyy");
     qDebug() << "Feed End Date . . ." << data->getEndDate().toString("dd-MMM-yyyy");
-    qDebug() << "Feed Version  . . ." << data->getVersion() << Qt::endl;
+    qDebug() << "Feed Version  . . ." << data->getVersion() << endl;
 }
 
 void ServeGTFS::incomingConnection(qintptr descriptor)

--- a/gtfsproc/server_main.cpp
+++ b/gtfsproc/server_main.cpp
@@ -33,14 +33,14 @@ int main(int argc, char *argv[])
      */
     QCoreApplication a(argc, argv);
     QCoreApplication::setApplicationName("GtfsProc");
-    QCoreApplication::setApplicationVersion("1.8b");
+    QCoreApplication::setApplicationVersion("1.8c");
 
     QTextStream console(stdout);
     QString appName = QCoreApplication::applicationName();
     QString appVers = QCoreApplication::applicationVersion();
 
     console << appName.remove("\"") << " version " << appVers.remove("\"")
-            << " - Running on Process ID: " << QCoreApplication::applicationPid() << Qt::endl << Qt::endl;
+            << " - Running on Process ID: " << QCoreApplication::applicationPid() << endl << endl;
 
     /*
      * Command Line Parsing
@@ -197,10 +197,10 @@ int main(int argc, char *argv[])
      * BEGIN LISTENING FOR CONNECTIONS
      */
     if (gtfsRequestServer.listen(QHostAddress::Any, portNum)) {
-        console << "SERVER STARTED - READY TO ACCEPT INCOMING CONNECTIONS" << Qt::endl << Qt::endl;
+        console << "SERVER STARTED - READY TO ACCEPT INCOMING CONNECTIONS" << endl << endl;
     } else {
         console << gtfsRequestServer.errorString();
-        console << Qt::endl << "(!) COULD NOT START SERVER - SEE ERROR STRING ABOVE" << Qt::endl;
+        console << endl << "(!) COULD NOT START SERVER - SEE ERROR STRING ABOVE" << endl;
         return 1;
     }
 

--- a/tests/CTTransit/stop_sequence_vs_stop_id_matching.test
+++ b/tests/CTTransit/stop_sequence_vs_stop_id_matching.test
@@ -62,7 +62,7 @@ to a stop in NEX/NCF.
             "url": "http://www.cttransit.com"
         }
     ],
-    "application": "GtfsProc 1.8b",
+    "application": "GtfsProc 1.8c",
 *   "appuptime_sec": 6,
 *   "dataloadtime_ms": 2830,
     "error": 0,

--- a/tests/CTTransit/trips_before_and_after_midnight.test
+++ b/tests/CTTransit/trips_before_and_after_midnight.test
@@ -59,7 +59,7 @@ case proves that both types of trips are visible to a single stop that is served
             "url": "http://www.cttransit.com"
         }
     ],
-    "application": "GtfsProc 1.8b",
+    "application": "GtfsProc 1.8c",
 *   "appuptime_sec": 16,
 *   "dataloadtime_ms": 2736,
     "error": 0,

--- a/tests/MBTA/after_midnights.test
+++ b/tests/MBTA/after_midnights.test
@@ -30,7 +30,7 @@ and canceled).
             "url": "http://www.mbta.com"
         }
     ],
-    "application": "GtfsProc 1.8b",
+    "application": "GtfsProc 1.8c",
 *   "appuptime_sec": 15,
 *   "dataloadtime_ms": 8034,
     "error": 0,

--- a/tests/RIPTA/trips_midnight_extrapolation.test
+++ b/tests/RIPTA/trips_midnight_extrapolation.test
@@ -27,7 +27,7 @@ offset prediction in a trip can be extrapolated from the last known offset.
             "url": "http://www.ripta.com/"
         }
     ],
-    "application": "GtfsProc 1.8b",
+    "application": "GtfsProc 1.8c",
 *   "appuptime_sec": 57,
 *   "dataloadtime_ms": 807,
     "error": 0,

--- a/tests/SEPTA_Rail/trips_before_and_after_midnight.test
+++ b/tests/SEPTA_Rail/trips_before_and_after_midnight.test
@@ -28,7 +28,7 @@ published with an offset, the remaining stops in a trip are assumed to have the 
             "url": "http://www.septa.org"
         }
     ],
-    "application": "GtfsProc 1.8b",
+    "application": "GtfsProc 1.8c",
 *   "appuptime_sec": 9,
 *   "dataloadtime_ms": 8,
     "error": 0,


### PR DESCRIPTION
Drop back endl / noforcesign calls to the Qt 5.12 style (undo the 5.15 warning fixes). Debian stable (as of this PR) is the reference platform for GtfsProc and so keep it compiling on that target.

Also ... actually compile and test [my] code changes ON TARGET next time :-P