### PR TITLE
Migrate to Qt 5.15.2

### DIFF
--- a/GtfsProc_Documentation.html
+++ b/GtfsProc_Documentation.html
@@ -36,7 +36,7 @@
     GtfsProc was written almost entirely in the Qt Application Framework. The TCP server code comes from Bryan Cairns of VoidRealms. See http://www.voidrealms.com/ for the original source and license. The GtfsProc code is written by Daniel Brook (danb358 {AT} gmail {DOT} com), (c) 2018-2021, GPL v 3.
 </p>
 <p>
-    This is the documentation for <b>GtfsProc Version 1.8b (25-Feb-2021)</b>
+    This is the documentation for <b>GtfsProc Version 1.8d (17-Aug-2021)</b>
 </p>
 
 <h1>Server Options</h1>
@@ -78,7 +78,7 @@
     </li>
 </ol>
 <div class="fixed">
-GtfsProc version 1.8b - Running on Process ID: 22112<br>
+GtfsProc version 1.8c - Running on Process ID: 22112<br>
 <br>
 Starting Feed Information Gathering ... <br>
 Starting Agency Gathering ...<br>

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -10,9 +10,9 @@ standalone server for a long period of time means data will go out of sync with
 any updated schedules.
 
 Several individual moving parts will help in this process:
-1) The following are required to build GtfsProc, install from your package manager:
-   Note: this is heavily Debian biased ;-)
-    - qt5-default
+1) The following are required to build GtfsProc, install from your package manager.
+   Note: this is heavily Debian biased (as Debian 11 is the reference system):
+    - build-essential
     - qt5-qmake
     - qtdeclarative5-dev
     - libcsv-dev

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,9 +1,16 @@
-THIS RELEASE: Version 1.8c Fixes
---------------------------------
+THIS RELEASE: Version 1.8d
+--------------------------
+- With the release of Debian 11, Qt 5.15.2 is now the reference framework. This release brings about
+  any technical changes for a clean compilation against the new libraries but no feature additions
+  or bug fixes.
+
+
+PREVIOUS RELEASES:
+Version 1.8c Fixes
+------------------
 - Revert the endl/Qt::endl/noforcesign change for Qt 5.15, it is incompatible with Qt 5.12 which
   Debian stable uses
 
-PREVIOUS RELEASES:
 Version 1.8b Features and Fixes
 -------------------------------
 - Update copyright dates

--- a/client_cli/clientgtfs.cpp
+++ b/client_cli/clientgtfs.cpp
@@ -178,7 +178,7 @@ void ClientGtfs::repl()
             screen << "GTFS Server Status"
                    << qSetFieldWidth(this->disp.getCols() - 18)      // 18 == "GTFS Server Status".length()
                    << respObj["message_time"].toString()
-                   << qSetFieldWidth(0) << endl << endl;
+                   << qSetFieldWidth(0) << Qt::endl << Qt::endl;
 
             // Easier to understand uptime
             qint64 uptimeMs = respObj["appuptime_ms"].toInt();
@@ -187,33 +187,33 @@ void ClientGtfs::repl()
             qint8  mins     = (uptimeMs - days * 86400000 - hours * 3600000) / 60000;
             qint8  secs     = (uptimeMs - days * 86400000 - hours * 3600000 - mins * 60000) / 1000;
 
-            screen << "[ Backend ]" << endl;
-            screen << "Processed Reqs . . " << respObj["processed_reqs"].toInt() << endl;
+            screen << "[ Backend ]" << Qt::endl;
+            screen << "Processed Reqs . . " << respObj["processed_reqs"].toInt() << Qt::endl;
             screen << "Uptime . . . . . . " << days  << "d " << qSetFieldWidth(2)
                                             << hours << "h "
                                             << mins  << "m "
-                                            << secs  << "s " << qSetFieldWidth(0) << endl;
-            screen << "Data Load Time . . " << respObj["dataloadtime_ms"].toInt() << "ms" << endl;
-            screen << "Thread Pool  . . . " << respObj["threadpool_count"].toInt() << endl;
-            screen << "System Version . . " << respObj["application"].toString() << endl << endl;
+                                            << secs  << "s " << qSetFieldWidth(0) << Qt::endl;
+            screen << "Data Load Time . . " << respObj["dataloadtime_ms"].toInt() << "ms" << Qt::endl;
+            screen << "Thread Pool  . . . " << respObj["threadpool_count"].toInt() << Qt::endl;
+            screen << "System Version . . " << respObj["application"].toString() << Qt::endl << Qt::endl;
 
-            screen << "[ Static Feed Information ]" << endl;
-            screen << "Publisher  . . . . " << respObj["feed_publisher"].toString() << endl;
-            screen << "URL  . . . . . . . " << respObj["feed_url"].toString() << endl;
-            screen << "Language . . . . . " << respObj["feed_lang"].toString() << endl;
+            screen << "[ Static Feed Information ]" << Qt::endl;
+            screen << "Publisher  . . . . " << respObj["feed_publisher"].toString() << Qt::endl;
+            screen << "URL  . . . . . . . " << respObj["feed_url"].toString() << Qt::endl;
+            screen << "Language . . . . . " << respObj["feed_lang"].toString() << Qt::endl;
             screen << "Valid Time . . . . " << "Start: " << respObj["feed_valid_start"].toString() << ", End: "
-                                            << respObj["feed_valid_end"].toString() << endl;
-            screen << "Version Text . . . " << respObj["feed_version"].toString() << endl;
-            screen << "Recs Loaded  . . . " << respObj["records"].toInt() << endl;
-            screen << endl;
+                                            << respObj["feed_valid_end"].toString() << Qt::endl;
+            screen << "Version Text . . . " << respObj["feed_version"].toString() << Qt::endl;
+            screen << "Recs Loaded  . . . " << respObj["records"].toInt() << Qt::endl;
+            screen << Qt::endl;
 
-            screen << "[ Agency Load ]" << endl;
+            screen << "[ Agency Load ]" << Qt::endl;
 
             screen.setFieldAlignment(QTextStream::AlignLeft);
             screen << qSetFieldWidth(c1) << "ID"        << qSetFieldWidth(1) << " "
                    << qSetFieldWidth(c2) << "NAME"      << qSetFieldWidth(1) << " "
                    << qSetFieldWidth(c3) << "TIMEZONE"  << qSetFieldWidth(1) << " "
-                   << qSetFieldWidth(c4) << "PHONE"     << qSetFieldWidth(0) << endl;
+                   << qSetFieldWidth(c4) << "PHONE"     << qSetFieldWidth(0) << Qt::endl;
 
             QJsonArray agencies = respObj["agencies"].toArray();
             for (const QJsonValue ag : agencies) {
@@ -221,10 +221,10 @@ void ClientGtfs::repl()
                        << qSetFieldWidth(c2) << ag["name"].toString().left(c2) << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c3) << ag["tz"].toString().left(c3)   << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c4) << ag["phone"].toString().left(c4)
-                       << qSetFieldWidth( 0) << endl;
+                       << qSetFieldWidth( 0) << Qt::endl;
             }
             screen.setFieldAlignment(QTextStream::AlignRight);
-            screen << endl;
+            screen << Qt::endl;
         }
 
         /*
@@ -245,17 +245,17 @@ void ClientGtfs::repl()
             screen << "Route List"
                    << qSetFieldWidth(this->disp.getCols() - 10)      // 10 == "Route List".length()
                    << respObj["message_time"].toString()
-                   << qSetFieldWidth(0) << endl << endl;
+                   << qSetFieldWidth(0) << Qt::endl << Qt::endl;
 
             // Useful data?
-            screen << "Query took " << respObj["proc_time_ms"].toInt() << " ms" << endl << endl;
+            screen << "Query took " << respObj["proc_time_ms"].toInt() << " ms" << Qt::endl << Qt::endl;
 
             // Start spitting out the routes
             screen.setFieldAlignment(QTextStream::AlignLeft);
             screen << qSetFieldWidth(c1) << "ID"         << qSetFieldWidth(1) << " "
                    << qSetFieldWidth(c2) << "SHORT NAME" << qSetFieldWidth(1) << " "
                    << qSetFieldWidth(c3) << "LONG NAME"  << qSetFieldWidth(1) << " "
-                   << qSetFieldWidth(c4) << "TRIPS"      << qSetFieldWidth(0) << endl;
+                   << qSetFieldWidth(c4) << "TRIPS"      << qSetFieldWidth(0) << Qt::endl;
 
             QJsonArray routes = respObj["routes"].toArray();
             for (const QJsonValue ro : routes) {
@@ -263,11 +263,11 @@ void ClientGtfs::repl()
                        << qSetFieldWidth(c2) << ro["short_name"].toString().left(c2) << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c3) << ro["long_name"].toString().left(c3)  << qSetFieldWidth(1) << " ";
                 screen.setFieldAlignment(QTextStream::AlignRight);
-                screen << qSetFieldWidth(c4) << ro["nb_trips"].toInt()               << qSetFieldWidth(0) << endl;
+                screen << qSetFieldWidth(c4) << ro["nb_trips"].toInt()               << qSetFieldWidth(0) << Qt::endl;
                 screen.setFieldAlignment(QTextStream::AlignLeft);
             }
 
-            screen << endl;
+            screen << Qt::endl;
             screen.setFieldAlignment(QTextStream::AlignRight);
         }
 
@@ -291,37 +291,37 @@ void ClientGtfs::repl()
             screen << "Trip Schedule"
                    << qSetFieldWidth(this->disp.getCols() - 13)
                    << respObj["message_time"].toString()
-                   << qSetFieldWidth(0) << endl << endl;
+                   << qSetFieldWidth(0) << Qt::endl << Qt::endl;
 
             if (respObj["error"].toInt() == 101) {
-                screen << "Trip not found in static database." << endl;
+                screen << "Trip not found in static database." << Qt::endl;
             } else if (respObj["error"].toInt() == 102) {
-                screen << "Trip not found in real-time data feed." << endl;
+                screen << "Trip not found in real-time data feed." << Qt::endl;
             } else {
                 bool realTimeData = respObj["real_time"].toBool();
 
-                screen << "Trip ID  . . . . . " << respObj["trip_id"].toString() << endl;
+                screen << "Trip ID  . . . . . " << respObj["trip_id"].toString() << Qt::endl;
                 if (!realTimeData) {
-                    screen << "Service ID . . . . " << respObj["service_id"].toString() << endl;
+                    screen << "Service ID . . . . " << respObj["service_id"].toString() << Qt::endl;
                     screen << "Validity . . . . . " << respObj["svc_start_date"].toString() << " - "
-                                                    << respObj["svc_end_date"].toString() << endl;
-                    screen << "Operating Days . . " << respObj["operate_days"].toString() << endl;
-                    screen << "Exceptions . . . . " << respObj["exception_dates"].toString() << endl;
-                    screen << "Additions  . . . . " << respObj["added_dates"].toString() << endl;
+                                                    << respObj["svc_end_date"].toString() << Qt::endl;
+                    screen << "Operating Days . . " << respObj["operate_days"].toString() << Qt::endl;
+                    screen << "Exceptions . . . . " << respObj["exception_dates"].toString() << Qt::endl;
+                    screen << "Additions  . . . . " << respObj["added_dates"].toString() << Qt::endl;
                 }
-                screen << "Route ID . . . . . " << respObj["route_id"].toString() << endl;
+                screen << "Route ID . . . . . " << respObj["route_id"].toString() << Qt::endl;
                 screen << "Route Name . . . . " << respObj["route_short_name"].toString() << ", \""
-                                                << respObj["route_long_name"].toString()  << "\"" << endl;
+                                                << respObj["route_long_name"].toString()  << "\"" << Qt::endl;
                 if (!realTimeData) {
-                    screen << "Headsign . . . . . " << respObj["headsign"].toString() << endl;
+                    screen << "Headsign . . . . . " << respObj["headsign"].toString() << Qt::endl;
                 } else {
-                    screen << "Vehicle  . . . . . " << respObj["vehicle"].toString() << endl;
+                    screen << "Vehicle  . . . . . " << respObj["vehicle"].toString() << Qt::endl;
                     screen << "Start Date&Time  . " << respObj["start_date"].toString() << " "
-                                                    << respObj["start_time"].toString() << endl;
-                    screen << "Real Time Data . . " << respObj["real_time_data_time"].toString() << endl;
+                                                    << respObj["start_time"].toString() << Qt::endl;
+                    screen << "Real Time Data . . " << respObj["real_time_data_time"].toString() << Qt::endl;
                 }
 
-                screen << "Short Name . . . . " << respObj["short_name"].toString() << endl << endl;
+                screen << "Short Name . . . . " << respObj["short_name"].toString() << Qt::endl << Qt::endl;
 
                 screen.setFieldAlignment(QTextStream::AlignLeft);
                 screen << qSetFieldWidth(c1)   << "SEQ"       << qSetFieldWidth(1) << " "
@@ -331,11 +331,11 @@ void ClientGtfs::repl()
                 if (!realTimeData) {
                     screen << qSetFieldWidth(c4*2) << "PD"        << qSetFieldWidth(1) << " "
                            << qSetFieldWidth(c5)   << "SCH-A"     << qSetFieldWidth(1) << " "
-                           << qSetFieldWidth(c6)   << "SCH-D"     << qSetFieldWidth(0) << endl;
+                           << qSetFieldWidth(c6)   << "SCH-D"     << qSetFieldWidth(0) << Qt::endl;
                 } else {
                     screen << qSetFieldWidth(c4*2) << "  "        << qSetFieldWidth(1) << " "
                            << qSetFieldWidth(c5)   << "PRE-A"     << qSetFieldWidth(1) << " "
-                           << qSetFieldWidth(c6)   << "PRE-D"     << qSetFieldWidth(0) << endl;
+                           << qSetFieldWidth(c6)   << "PRE-D"     << qSetFieldWidth(0) << Qt::endl;
                 }
 
                 QJsonArray stops = respObj["stops"].toArray();
@@ -349,11 +349,11 @@ void ClientGtfs::repl()
                            << qSetFieldWidth(c4) << pickUp << dropOff                   << qSetFieldWidth(1) << " ";
                     screen.setFieldAlignment(QTextStream::AlignRight);
                     screen << qSetFieldWidth(c5) << st["arr_time"].toString() << qSetFieldWidth(1) << " "
-                           << qSetFieldWidth(c6) << st["dep_time"].toString() << qSetFieldWidth(0) << endl;
+                           << qSetFieldWidth(c6) << st["dep_time"].toString() << qSetFieldWidth(0) << Qt::endl;
                     screen.setFieldAlignment(QTextStream::AlignLeft);
                 }
             }
-            screen << endl;
+            screen << Qt::endl;
             screen.setFieldAlignment(QTextStream::AlignRight);
         }
 
@@ -377,16 +377,16 @@ void ClientGtfs::repl()
             screen << "Trips Serving Route"
                    << qSetFieldWidth(this->disp.getCols() - 19)
                    << respObj["message_time"].toString()
-                   << qSetFieldWidth(0) << endl << endl;
+                   << qSetFieldWidth(0) << Qt::endl << Qt::endl;
 
             if (respObj["error"].toInt() == 201) {
-                screen << "Route not found." << endl;
+                screen << "Route not found." << Qt::endl;
             }
             else {
-                screen << "Route ID . . . . . " << respObj["route_id"].toString() << endl;
+                screen << "Route ID . . . . . " << respObj["route_id"].toString() << Qt::endl;
                 screen << "Route Name . . . . " << respObj["route_short_name"].toString() << ", \""
-                                                << respObj["route_long_name"].toString()  << "\"" << endl;
-                screen << "Service Date . . . " << respObj["service_date"].toString() << endl << endl;
+                                                << respObj["route_long_name"].toString()  << "\"" << Qt::endl;
+                screen << "Service Date . . . " << respObj["service_date"].toString() << Qt::endl << Qt::endl;
 
                 // Loop on all the trips
                 screen.setFieldAlignment(QTextStream::AlignLeft);
@@ -395,7 +395,7 @@ void ClientGtfs::repl()
                        << qSetFieldWidth(c3*2+1) << "VALID-DURATION" << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c4)     << "OPERATING-DAYS" << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c5*2)   << "ES"             << qSetFieldWidth(1) << " "
-                       << qSetFieldWidth(c6)     << "SCH-D"          << qSetFieldWidth(0) << endl;
+                       << qSetFieldWidth(c6)     << "SCH-D"          << qSetFieldWidth(0) << Qt::endl;
 
                 QJsonArray trips = respObj["trips"].toArray();
                 for (const QJsonValue tr : trips) {
@@ -412,15 +412,15 @@ void ClientGtfs::repl()
                            << qSetFieldWidth(1) << dstOn;
                     screen.setFieldAlignment(QTextStream::AlignRight);
                     screen << qSetFieldWidth(c6) << tr["first_stop_departure"].toString()
-                           << qSetFieldWidth(0) << endl;
+                           << qSetFieldWidth(0) << Qt::endl;
                     screen.setFieldAlignment(QTextStream::AlignLeft);
                 }
 
-                screen << endl << "Query took " << respObj["proc_time_ms"].toInt() << " ms, "
-                       << trips.size() << " records loaded" << endl;
+                screen << Qt::endl << "Query took " << respObj["proc_time_ms"].toInt() << " ms, "
+                       << trips.size() << " records loaded" << Qt::endl;
             }
 
-            screen << endl;
+            screen << Qt::endl;
             screen.setFieldAlignment(QTextStream::AlignRight);
         }
 
@@ -445,20 +445,20 @@ void ClientGtfs::repl()
             screen << "Trips Serving Stop"
                    << qSetFieldWidth(this->disp.getCols() - 18)
                    << respObj["message_time"].toString()
-                   << qSetFieldWidth(0) << endl << endl;
+                   << qSetFieldWidth(0) << Qt::endl << Qt::endl;
 
             if (respObj["error"].toInt() == 301) {
-                screen << "Stop not found." << endl;
+                screen << "Stop not found." << Qt::endl;
             }
             else {
                 // Count how many records were returned
                 qint32 tripsLoaded = 0;
 
-                screen << "Stop ID  . . . . . " << respObj["stop_id"].toString() << endl
-                       << "Stop Name  . . . . " << respObj["stop_name"].toString() << endl
-                       << "Stop Desc  . . . . " << respObj["stop_desc"].toString() << endl
-                       << "Parent Station . . " << respObj["parent_sta"].toString() << endl
-                       << "Service Date . . . " << respObj["service_date"].toString() << endl << endl;
+                screen << "Stop ID  . . . . . " << respObj["stop_id"].toString() << Qt::endl
+                       << "Stop Name  . . . . " << respObj["stop_name"].toString() << Qt::endl
+                       << "Stop Desc  . . . . " << respObj["stop_desc"].toString() << Qt::endl
+                       << "Parent Station . . " << respObj["parent_sta"].toString() << Qt::endl
+                       << "Service Date . . . " << respObj["service_date"].toString() << Qt::endl << Qt::endl;
 
                 // ... then all the trips within each route
                 screen.setFieldAlignment(QTextStream::AlignLeft);
@@ -468,14 +468,14 @@ void ClientGtfs::repl()
                        << qSetFieldWidth(c4*2+1) << "VALID-DURATION" << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c5)     << "OPERATING-DAYS" << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c6*5)   << "ES TPD"         << qSetFieldWidth(1) << " "
-                       << qSetFieldWidth(c7)     << "SCH-D"          << qSetFieldWidth(0) << endl << endl;
+                       << qSetFieldWidth(c7)     << "SCH-D"          << qSetFieldWidth(0) << Qt::endl << Qt::endl;
 
                 // Loop on all the routes
                 QJsonArray routes = respObj["routes"].toArray();
                 for (const QJsonValue ro : routes) {
                     screen << "[ Route ID " << ro["route_id"].toString() << " :: "
                                             << ro["route_short_name"].toString() << " :: "
-                                            << ro["route_long_name"].toString()  << " ]"   << endl;
+                                            << ro["route_long_name"].toString()  << " ]"   << Qt::endl;
 
                     // Loop on all the trips
                     QJsonArray trips = ro["trips"].toArray();
@@ -512,18 +512,18 @@ void ClientGtfs::repl()
                                << qSetFieldWidth(c6) << svcExempt << svcSplmnt << " " << tripTerm << pickUp << dropOff
                                << qSetFieldWidth(1) << dstIndic;
                         screen.setFieldAlignment(QTextStream::AlignRight);
-                        screen << qSetFieldWidth(c7) << tr["dep_time"].toString() << qSetFieldWidth(0) << endl;
+                        screen << qSetFieldWidth(c7) << tr["dep_time"].toString() << qSetFieldWidth(0) << Qt::endl;
                         screen.setFieldAlignment(QTextStream::AlignLeft);
                     } // End loop on Trips-within-Route
                     tripsLoaded += trips.size();
-                    screen << endl;
+                    screen << Qt::endl;
                 } // End loop on Routes-serving-Stop
 
                 screen << "Query took " << respObj["proc_time_ms"].toInt() << " ms, "
-                       << tripsLoaded << " trips loaded" << endl;
+                       << tripsLoaded << " trips loaded" << Qt::endl;
             }
 
-            screen << endl;
+            screen << Qt::endl;
             screen.setFieldAlignment(QTextStream::AlignRight);
         }
 
@@ -544,25 +544,25 @@ void ClientGtfs::repl()
             screen << "Individual Stop Service Information"
                    << qSetFieldWidth(this->disp.getCols() - 35)
                    << respObj["message_time"].toString()
-                   << qSetFieldWidth(0) << endl << endl;
+                   << qSetFieldWidth(0) << Qt::endl << Qt::endl;
 
             if (respObj["error"].toInt() == 401) {
-                screen << "Stop not found." << endl;
+                screen << "Stop not found." << Qt::endl;
             }
             else {
                 screen << "Stop ID/Name . . . " << respObj["stop_id"].toString() << " :: "
-                                                << respObj["stop_name"].toString() << endl;
-                screen << "Stop Desc  . . . . " << respObj["stop_desc"].toString() << endl;
+                                                << respObj["stop_name"].toString() << Qt::endl;
+                screen << "Stop Desc  . . . . " << respObj["stop_desc"].toString() << Qt::endl;
                 screen << "Location . . . . . " << respObj["loc_lat"].toString() << ", "
-                                                << respObj["loc_lon"].toString() << endl;
-                screen << "Parent Station . . " << respObj["parent_sta"].toString() << endl << endl;
+                                                << respObj["loc_lon"].toString() << Qt::endl;
+                screen << "Parent Station . . " << respObj["parent_sta"].toString() << Qt::endl << Qt::endl;
 
                 // Show all the Routes associated with the station requested
                 screen.setFieldAlignment(QTextStream::AlignLeft);
-                screen << "[ Routes Serving Stop ]" << endl;
+                screen << "[ Routes Serving Stop ]" << Qt::endl;
                 screen << qSetFieldWidth(c1) << "ROUTE-ID"         << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c2) << "ROUTE-NAME-SHORT" << qSetFieldWidth(1) << " "
-                       << qSetFieldWidth(c3) << "ROUTE-NAME-LONG"  << qSetFieldWidth(1) << endl;
+                       << qSetFieldWidth(c3) << "ROUTE-NAME-LONG"  << qSetFieldWidth(1) << Qt::endl;
 
                 // Loop on all the routes
                 QJsonArray routes = respObj["routes"].toArray();
@@ -572,29 +572,29 @@ void ClientGtfs::repl()
                            << qSetFieldWidth(c2) << ro["route_short_name"].toString().left(c2)
                            << qSetFieldWidth(1) << " "
                            << qSetFieldWidth(c3) << ro["route_long_name"].toString().left(c3)
-                           << qSetFieldWidth(0) << endl;
+                           << qSetFieldWidth(0) << Qt::endl;
                 }
-                screen << endl;
+                screen << Qt::endl;
 
                 // Then display any associated stations with the parent
                 screen.setFieldAlignment(QTextStream::AlignLeft);
-                screen << "[ Stops Sharing Parent Station ]" << endl;
+                screen << "[ Stops Sharing Parent Station ]" << Qt::endl;
                 screen << qSetFieldWidth(c1) << "STOP-ID"   << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c2) << "STOP-NAME" << qSetFieldWidth(1) << " "
-                       << qSetFieldWidth(c3) << "STOP-DESC" << qSetFieldWidth(1) << endl;
+                       << qSetFieldWidth(c3) << "STOP-DESC" << qSetFieldWidth(1) << Qt::endl;
 
                 QJsonArray sharedStops = respObj["stops_sharing_parent"].toArray();
                 for (const QJsonValue ss : sharedStops) {
                     screen << qSetFieldWidth(c1) << ss["stop_id"].toString().left(c1)   << qSetFieldWidth(1) << " "
                            << qSetFieldWidth(c2) << ss["stop_name"].toString().left(c2) << qSetFieldWidth(1) << " "
                            << qSetFieldWidth(c3) << ss["stop_desc"].toString().left(c3)
-                           << qSetFieldWidth(0)  << endl;
+                           << qSetFieldWidth(0)  << Qt::endl;
                 }
-                screen << endl;
-                screen << "Query took " << respObj["proc_time_ms"].toInt() << " ms" << endl;
+                screen << Qt::endl;
+                screen << "Query took " << respObj["proc_time_ms"].toInt() << " ms" << Qt::endl;
             }
 
-            screen << endl;
+            screen << Qt::endl;
             screen.setFieldAlignment(QTextStream::AlignRight);
         }
 
@@ -617,29 +617,29 @@ void ClientGtfs::repl()
             screen << "Route Summary and Stop Information"
                    << qSetFieldWidth(this->disp.getCols() - 34)
                    << respObj["message_time"].toString()
-                   << qSetFieldWidth(0) << endl << endl;
+                   << qSetFieldWidth(0) << Qt::endl << Qt::endl;
 
             if (respObj["error"].toInt() == 501) {
-                screen << "Route not found." << endl;
+                screen << "Route not found." << Qt::endl;
             }
             else {
-                screen << "Route ID . . . . . " << respObj["route_id"].toString() << endl
-                       << "Short Name . . . . " << respObj["route_short_name"].toString() << endl
-                       << "Long Name  . . . . " << respObj["route_long_name"].toString() << endl
-                       << "Description  . . . " << respObj["route_desc"].toString() << endl
-                       << "Type . . . . . . . " << respObj["route_type"].toString() << endl
-                       << "URL  . . . . . . . " << respObj["route_url"].toString() << endl
-                       << "Color  . . . . . . " << respObj["route_color"].toString() << endl
-                       << "Text Color . . . . " << respObj["route_text_color"].toString() << endl << endl;
+                screen << "Route ID . . . . . " << respObj["route_id"].toString() << Qt::endl
+                       << "Short Name . . . . " << respObj["route_short_name"].toString() << Qt::endl
+                       << "Long Name  . . . . " << respObj["route_long_name"].toString() << Qt::endl
+                       << "Description  . . . " << respObj["route_desc"].toString() << Qt::endl
+                       << "Type . . . . . . . " << respObj["route_type"].toString() << Qt::endl
+                       << "URL  . . . . . . . " << respObj["route_url"].toString() << Qt::endl
+                       << "Color  . . . . . . " << respObj["route_color"].toString() << Qt::endl
+                       << "Text Color . . . . " << respObj["route_text_color"].toString() << Qt::endl << Qt::endl;
 
                 // Show all the Routes associated with the station requested
                 screen.setFieldAlignment(QTextStream::AlignLeft);
-                screen << "[ Stops Served by Route ]" << endl;
+                screen << "[ Stops Served by Route ]" << Qt::endl;
                 screen << qSetFieldWidth(c1)     << "STOP-ID"   << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c2)     << "STOP-NAME" << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c3)     << "STOP-DESC" << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c4)     << "#TRIPS"    << qSetFieldWidth(1) << " "
-                       << qSetFieldWidth(c5 * 2) << "LOCATION"  << qSetFieldWidth(1) << endl;
+                       << qSetFieldWidth(c5 * 2) << "LOCATION"  << qSetFieldWidth(1) << Qt::endl;
 
                 // Loop on all the routes
                 QJsonArray stops = respObj["stops"].toArray();
@@ -651,10 +651,10 @@ void ClientGtfs::repl()
                     screen << qSetFieldWidth(c4) << so["trip_count"].toInt()            << qSetFieldWidth(1) << " "
                            << qSetFieldWidth(c5) << so["stop_lat"].toString().left(c5)  << qSetFieldWidth(1) << ","
                            << qSetFieldWidth(c5) << so["stop_lon"].toString().left(c5)
-                           << qSetFieldWidth(0)  << endl;
+                           << qSetFieldWidth(0)  << Qt::endl;
                     screen.setFieldAlignment(QTextStream::AlignLeft);
                 }
-                screen << endl;
+                screen << Qt::endl;
             }
             screen.setFieldAlignment(QTextStream::AlignRight);
         }
@@ -680,18 +680,18 @@ void ClientGtfs::repl()
             screen << "Upcoming Service at Stop"
                    << qSetFieldWidth(this->disp.getCols() - 24)
                    << respObj["message_time"].toString()
-                   << qSetFieldWidth(0) << endl << endl;
+                   << qSetFieldWidth(0) << Qt::endl << Qt::endl;
 
             if (respObj["error"].toInt() == 601) {
-                screen << "Stop not found." << endl;
+                screen << "Stop not found." << Qt::endl;
             }
             else {
                 // Count how many records were returned
                 qint32 tripsLoaded = 0;
 
-                screen << "Stop ID  . . . . . " << respObj["stop_id"].toString()   << endl
-                       << "Stop Name  . . . . " << respObj["stop_name"].toString() << endl
-                       << "Stop Desc  . . . . " << respObj["stop_desc"].toString() << endl << endl;
+                screen << "Stop ID  . . . . . " << respObj["stop_id"].toString()   << Qt::endl
+                       << "Stop Name  . . . . " << respObj["stop_name"].toString() << Qt::endl
+                       << "Stop Desc  . . . . " << respObj["stop_desc"].toString() << Qt::endl << Qt::endl;
 
                 // ... then all the trips within each route
                 screen.setFieldAlignment(QTextStream::AlignLeft);
@@ -701,12 +701,12 @@ void ClientGtfs::repl()
                        << qSetFieldWidth(c4*3) << "TPD"       << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c5)   << "STOP-TIME" << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c6)   << "MINS"      << qSetFieldWidth(1) << " "
-                       << qSetFieldWidth(c7)   << "STAT"      << qSetFieldWidth(0) << endl;
+                       << qSetFieldWidth(c7)   << "STAT"      << qSetFieldWidth(0) << Qt::endl;
 
                 // Loop on all the routes
                 QJsonArray routes = respObj["routes"].toArray();
                 for (const QJsonValue ro : routes) {
-                    screen << "[ Route ID " << ro["route_id"].toString() << " ]"   << endl;
+                    screen << "[ Route ID " << ro["route_id"].toString() << " ]"   << Qt::endl;
 
                     // Loop on all the trips
                     QJsonArray trips = ro["trips"].toArray();
@@ -794,7 +794,7 @@ void ClientGtfs::repl()
                                     if (offsetSec < -60 || offsetSec > 60) {
                                         screen.setNumberFlags(QTextStream::ForceSign);
                                         screen << qSetFieldWidth(c7) << offsetSec / 60 << qSetFieldWidth(0);
-                                        noforcesign(screen);
+                                        Qt::noforcesign(screen);
                                     } else {
                                         screen << qSetFieldWidth(c7) << "ONTM" << qSetFieldWidth(0);
                                     }
@@ -815,19 +815,19 @@ void ClientGtfs::repl()
                         }
 
                         screen.setFieldAlignment(QTextStream::AlignLeft);
-                        screen << endl;
+                        screen << Qt::endl;
 
                     } // End loop on Trips-within-Route
 
                     tripsLoaded += trips.size();
-                    screen << endl;
+                    screen << Qt::endl;
                 } // End loop on Routes-serving-Stop
 
                 screen << "Query took " << respObj["proc_time_ms"].toInt() << " ms, "
-                       << tripsLoaded << " trips loaded" << endl;
+                       << tripsLoaded << " trips loaded" << Qt::endl;
             }
 
-            screen << endl;
+            screen << Qt::endl;
             screen.setFieldAlignment(QTextStream::AlignRight);
         }
 
@@ -853,18 +853,18 @@ void ClientGtfs::repl()
             screen << "Upcoming Service at Stop"
                    << qSetFieldWidth(this->disp.getCols() - 24)
                    << respObj["message_time"].toString()
-                   << qSetFieldWidth(0) << endl << endl;
+                   << qSetFieldWidth(0) << Qt::endl << Qt::endl;
 
             if (respObj["error"].toInt() == 601) {
-                screen << "Stop not found." << endl;
+                screen << "Stop not found." << Qt::endl;
             }
             else {
                 // Count how many records were returned
                 qint32 tripsLoaded = 0;
 
-                screen << "Stop ID  . . . . . " << respObj["stop_id"].toString()   << endl
-                       << "Stop Name  . . . . " << respObj["stop_name"].toString() << endl
-                       << "Stop Desc  . . . . " << respObj["stop_desc"].toString() << endl << endl;
+                screen << "Stop ID  . . . . . " << respObj["stop_id"].toString()   << Qt::endl
+                       << "Stop Name  . . . . " << respObj["stop_name"].toString() << Qt::endl
+                       << "Stop Desc  . . . . " << respObj["stop_desc"].toString() << Qt::endl << Qt::endl;
 
                 // ... then all the trips within each route
                 screen.setFieldAlignment(QTextStream::AlignLeft);
@@ -875,7 +875,7 @@ void ClientGtfs::repl()
                        << qSetFieldWidth(c5*3) << "TPD"       << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c6)   << "STOP-TIME" << qSetFieldWidth(1) << " "
                        << qSetFieldWidth(c7)   << "MINS"      << qSetFieldWidth(1) << " "
-                       << qSetFieldWidth(c8)   << "STAT"      << qSetFieldWidth(0) << endl;
+                       << qSetFieldWidth(c8)   << "STAT"      << qSetFieldWidth(0) << Qt::endl;
 
                 // Loop on all the trips
                 QJsonArray trips = respObj["trips"].toArray();
@@ -964,7 +964,7 @@ void ClientGtfs::repl()
                                 if (offsetSec < -60 || offsetSec > 60) {
                                     screen.setNumberFlags(QTextStream::ForceSign);
                                     screen << qSetFieldWidth(c8) << offsetSec / 60 << qSetFieldWidth(0);
-                                    noforcesign(screen);
+                                    Qt::noforcesign(screen);
                                 } else {
                                     screen << qSetFieldWidth(c8) << "ONTM" << qSetFieldWidth(0);
                                 }
@@ -985,18 +985,18 @@ void ClientGtfs::repl()
                     }
 
                     screen.setFieldAlignment(QTextStream::AlignLeft);
-                    screen << endl;
+                    screen << Qt::endl;
 
                 } // End loop on Trips-within-Route
 
                 tripsLoaded += trips.size();
-                screen << endl;
+                screen << Qt::endl;
 
                 screen << "Query took " << respObj["proc_time_ms"].toInt() << " ms, "
-                       << tripsLoaded << " trips loaded" << endl;
+                       << tripsLoaded << " trips loaded" << Qt::endl;
             }
 
-            screen << endl;
+            screen << Qt::endl;
             screen.setFieldAlignment(QTextStream::AlignRight);
         }
 
@@ -1018,13 +1018,13 @@ void ClientGtfs::repl()
             screen << "Stops Without Trips"
                    << qSetFieldWidth(this->disp.getCols() - 19)
                    << respObj["message_time"].toString()
-                   << qSetFieldWidth(0) << endl << endl;
+                   << qSetFieldWidth(0) << Qt::endl << Qt::endl;
 
             screen.setFieldAlignment(QTextStream::AlignLeft);
             screen << qSetFieldWidth(c1) << "STOP-ID"   << qSetFieldWidth(1) << " "
                    << qSetFieldWidth(c2) << "STOP-NAME" << qSetFieldWidth(1) << " "
                    << qSetFieldWidth(c3) << "STOP-DESC" << qSetFieldWidth(1) << " "
-                   << qSetFieldWidth(c4) << "LOCATION"  << qSetFieldWidth(1) << endl;
+                   << qSetFieldWidth(c4) << "LOCATION"  << qSetFieldWidth(1) << Qt::endl;
 
             // Loop on all the routes
             QJsonArray stops = respObj["stops"].toArray();
@@ -1039,10 +1039,10 @@ void ClientGtfs::repl()
                 screen << qSetFieldWidth(c4/2) << st["loc_lat"].toString().left(c4/2)
                        << qSetFieldWidth(1)    << ","
                        << qSetFieldWidth(c4/2) << st["loc_lon"].toString().left(c4/2)
-                       << qSetFieldWidth(0)    << endl;
+                       << qSetFieldWidth(0)    << Qt::endl;
                 screen.setFieldAlignment(QTextStream::AlignLeft);
             }
-            screen << endl << "Query took " << respObj["proc_time_ms"].toInt() << " ms" << endl << endl;
+            screen << Qt::endl << "Query took " << respObj["proc_time_ms"].toInt() << " ms" << Qt::endl << Qt::endl;
             screen.setFieldAlignment(QTextStream::AlignRight);
         }
 
@@ -1062,40 +1062,40 @@ void ClientGtfs::repl()
             screen << "GTFS Realtime Data Status"
                    << qSetFieldWidth(this->disp.getCols() - 25)
                    << respObj["message_time"].toString()
-                   << qSetFieldWidth(0) << endl << endl;
+                   << qSetFieldWidth(0) << Qt::endl << Qt::endl;
 
             screen.setFieldAlignment(QTextStream::AlignLeft);
 
             // Mutual Exclusion
-            screen << "[ Mutual Exclusion ]" << endl
-                   << "Active Side  . . . " << respObj["active_side"].toString() << endl
-                   << "Data Age . . . . . " << respObj["active_age_sec"].toInt() << " s" << endl
-                   << "Feed Time  . . . . " << respObj["active_feed_time"].toString() << endl
-                   << "Download Time  . . " << respObj["active_download_ms"].toInt() << " ms" << endl
-                   << "Integ Time . . . . " << respObj["active_integration_ms"].toInt() << " ms" << endl
-                   << "Next Fetch In  . . " << respObj["seconds_to_next_fetch"].toInt() << " s" << endl
-                   << "Latest RT Txn  . . " << respObj["last_realtime_query"].toString() << endl
-                   << endl << endl;
+            screen << "[ Mutual Exclusion ]" << Qt::endl
+                   << "Active Side  . . . " << respObj["active_side"].toString() << Qt::endl
+                   << "Data Age . . . . . " << respObj["active_age_sec"].toInt() << " s" << Qt::endl
+                   << "Feed Time  . . . . " << respObj["active_feed_time"].toString() << Qt::endl
+                   << "Download Time  . . " << respObj["active_download_ms"].toInt() << " ms" << Qt::endl
+                   << "Integ Time . . . . " << respObj["active_integration_ms"].toInt() << " ms" << Qt::endl
+                   << "Next Fetch In  . . " << respObj["seconds_to_next_fetch"].toInt() << " s" << Qt::endl
+                   << "Latest RT Txn  . . " << respObj["last_realtime_query"].toString() << Qt::endl
+                   << Qt::endl << Qt::endl;
 
 
             screen << qSetFieldWidth(c1) << "TRIP-ID"   << qSetFieldWidth(1) << " "
-                   << qSetFieldWidth(c2) << "ROUTE-ID"  << qSetFieldWidth(1) << endl;
+                   << qSetFieldWidth(c2) << "ROUTE-ID"  << qSetFieldWidth(1) << Qt::endl;
 
             // Loop on all the routes
             //QJsonArray stops = respObj["stops"].toArray();
 
-            screen << endl << "Query took " << respObj["proc_time_ms"].toInt() << " ms" << endl << endl;
+            screen << Qt::endl << "Query took " << respObj["proc_time_ms"].toInt() << " ms" << Qt::endl << Qt::endl;
             screen.setFieldAlignment(QTextStream::AlignRight);
         }
 
         // Probably some kind of error condition, just respond in kind
         else {
-            screen << endl << "No handler for the request: " << endl << responseStr << endl;
+            screen << Qt::endl << "No handler for the request: " << Qt::endl << responseStr << Qt::endl;
         }
     }
 
     // On exit (loop halted above)
-    screen << "*** DISCONNECTING ***" << endl;
+    screen << "*** DISCONNECTING ***" << Qt::endl;
 }
 
 QString ClientGtfs::dropoffToChar(qint8 svcDropOff)

--- a/client_cli/structureddisplay.cpp
+++ b/client_cli/structureddisplay.cpp
@@ -70,42 +70,42 @@ void Display::displayWelcome()
     //
     QTextStream screen(stdout);
     screen << buffer << "GTFS Interactive Data Console -- Version: "
-                     << QCoreApplication::applicationVersion() << endl
-           << endl
-           << "[ System Information ]" << endl
-           << "SDS: Backend system and data load status" << endl
-           << "RDS: GTFS Real-Time data retrieval status" << endl
-           << "RTE: Routes available from the data set" << endl
-           << "SSR: List of all stops served by a single route" << endl
-           << "SNT: List all stops that have no trips (diagnostic)" << endl
-           << endl
-           << "[ Full Schedule Lookup ]" << endl
-           << "STA: Stop information lookup by stop_id" << endl
-           << "TSR: List of trips serving a route_id" << endl
-           << "TSS: List of trips serving a stop_id" << endl
-           << "TRI: List all the stops served by a trip_id" << endl
-           << "RTS/RTF/RTT: List the real-time data of an active trip_id or update" << endl
-           << endl
-           << "[ Data Lookup for Specific Date ]" << endl
-           << "TRD: List of trips serving a route_id on a date" << endl
-           << "TSD: List of trips serving a stop_id on a date" << endl
-           << "NEX: List upcoming trips serving a stop_id within a number of minutes" << endl
-           << endl
+                     << QCoreApplication::applicationVersion() << Qt::endl
+           << Qt::endl
+           << "[ System Information ]" << Qt::endl
+           << "SDS: Backend system and data load status" << Qt::endl
+           << "RDS: GTFS Real-Time data retrieval status" << Qt::endl
+           << "RTE: Routes available from the data set" << Qt::endl
+           << "SSR: List of all stops served by a single route" << Qt::endl
+           << "SNT: List all stops that have no trips (diagnostic)" << Qt::endl
+           << Qt::endl
+           << "[ Full Schedule Lookup ]" << Qt::endl
+           << "STA: Stop information lookup by stop_id" << Qt::endl
+           << "TSR: List of trips serving a route_id" << Qt::endl
+           << "TSS: List of trips serving a stop_id" << Qt::endl
+           << "TRI: List all the stops served by a trip_id" << Qt::endl
+           << "RTS/RTF/RTT: List the real-time data of an active trip_id or update" << Qt::endl
+           << Qt::endl
+           << "[ Data Lookup for Specific Date ]" << Qt::endl
+           << "TRD: List of trips serving a route_id on a date" << Qt::endl
+           << "TSD: List of trips serving a stop_id on a date" << Qt::endl
+           << "NEX: List upcoming trips serving a stop_id within a number of minutes" << Qt::endl
+           << Qt::endl
            << "Reinitialize the display with 'HOM', quit using 'BYE'"
-           << endl << endl;
+           << Qt::endl << Qt::endl;
 }
 
 void Display::showServer(QString hostname, int port)
 {
     QTextStream screen(stdout);
-    screen << "Connected to: " << hostname << " : " << port << endl;
+    screen << "Connected to: " << hostname << " : " << port << Qt::endl;
     screen.flush();
 }
 
 void Display::showError(QString errorText)
 {
     QTextStream screen(stdout);
-    screen << "Error: " << errorText << endl;
+    screen << "Error: " << errorText << Qt::endl;
     screen.flush();
 }
 

--- a/gtfs_modules/realtimetripinformation.cpp
+++ b/gtfs_modules/realtimetripinformation.cpp
@@ -52,7 +52,7 @@ void RealtimeTripInformation::fillResponseData(QJsonObject &resp)
     QJsonObject canceledCollection;
     for (const QString &routeID : cancelledRouteTrips.keys()) {
         QJsonArray canceledRoute;
-        for (const QString &tripID : cancelledRouteTrips[routeID]) {
+        for (const QString &tripID : qAsConst(cancelledRouteTrips[routeID])) {
             canceledRoute.push_back(tripID);
         }
         canceledCollection[routeID] = canceledRoute;
@@ -63,7 +63,7 @@ void RealtimeTripInformation::fillResponseData(QJsonObject &resp)
     QJsonObject addedCollection;
     for (const QString &routeID : addedRouteTrips.keys()) {
         QJsonArray addedRoute;
-        for (const QString &tripID : addedRouteTrips[routeID]) {
+        for (const QString &tripID : qAsConst(addedRouteTrips[routeID])) {
             addedRoute.push_back(tripID);
         }
         addedCollection[routeID] = addedRoute;
@@ -74,7 +74,7 @@ void RealtimeTripInformation::fillResponseData(QJsonObject &resp)
     QJsonObject activeCollection;
     for (const QString &routeID : activeRouteTrips.keys()) {
         QJsonArray activeRoute;
-        for (const QString &tripID : activeRouteTrips[routeID]) {
+        for (const QString &tripID : qAsConst(activeRouteTrips[routeID])) {
             activeRoute.push_back(tripID);
         }
         activeCollection[routeID] = activeRoute;
@@ -83,7 +83,7 @@ void RealtimeTripInformation::fillResponseData(QJsonObject &resp)
 
     // Routes without Trips / "Orphaned Trips"
     QJsonArray orphanedAll;
-    for (const QString &tripID : tripsWithoutRoute) {
+    for (const QString &tripID : qAsConst(tripsWithoutRoute)) {
         orphanedAll.push_back(tripID);
     }
     resp["orphaned_trips"] = orphanedAll;
@@ -92,7 +92,7 @@ void RealtimeTripInformation::fillResponseData(QJsonObject &resp)
     QJsonObject mismatchCollection;
     for (const QString &routeID : mismatchTripIdx.keys()) {
         QJsonArray mismatchRoute;
-        for (const QString &tripID : mismatchTripIdx[routeID]) {
+        for (const QString &tripID : qAsConst(mismatchTripIdx[routeID])) {
             mismatchRoute.push_back(tripID);
         }
         mismatchCollection[routeID] = mismatchRoute;
@@ -105,7 +105,7 @@ void RealtimeTripInformation::fillResponseData(QJsonObject &resp)
         QJsonObject duplicateRoutes;
         for (const QString &tripID : duplicateTripIdx[routeID].keys()) {
             QJsonArray duplicateTripsRoute;
-            for (qint32 rttuEntityIdx: duplicateTripIdx[routeID][tripID]) {
+            for (qint32 rttuEntityIdx : qAsConst(duplicateTripIdx[routeID][tripID])) {
                 duplicateTripsRoute.push_back(rttuEntityIdx);
             }
             duplicateRoutes[tripID] = duplicateTripsRoute;

--- a/gtfs_modules/servicebetweenstops.cpp
+++ b/gtfs_modules/servicebetweenstops.cpp
@@ -102,10 +102,10 @@ void ServiceBetweenStops::fillResponseData(QJsonObject &resp)
     QSet<QString> tripsPickingUpOrigin;
     QSet<QString> tripsDroppingOffDestination;
 
-    for (const QString &childStop : oriStopIDs) {
+    for (const QString &childStop : qAsConst(oriStopIDs)) {
         tripsForServiceDay(childStop, tripsPickingUpOrigin, true, tripSchTimes);
     }
-    for (const QString &childStop : desStopIDs) {
+    for (const QString &childStop : qAsConst(desStopIDs)) {
         tripsForServiceDay(childStop, tripsDroppingOffDestination, false, tripSchTimes);
     }
     tripsPickingUpOrigin.intersect(tripsDroppingOffDestination);
@@ -115,7 +115,7 @@ void ServiceBetweenStops::fillResponseData(QJsonObject &resp)
      * arrival/departure at origin, and arrival/departure time at destination.
      */
     QVector<tripOnDSchedule> commonTrips;
-    for (const QString &tripID : tripsPickingUpOrigin) {
+    for (const QString &tripID : qAsConst(tripsPickingUpOrigin)) {
         tripOnDSchedule singleTrip;
         singleTrip.oriStopSeq   = tripSchTimes[tripID].oriStopSeq;
         singleTrip.desStopSeq   = tripSchTimes[tripID].desStopSeq;

--- a/gtfs_modules/stationdetailsdisplay.cpp
+++ b/gtfs_modules/stationdetailsdisplay.cpp
@@ -73,7 +73,7 @@ void StationDetailsDisplay::fillResponseData(QJsonObject &resp)
     resp["loc_lon"]    = (*_stops)[_stopID].stop_lon;
 
     // Find more details about all the routes served by the station
-    for (const QString &routeID : listOfRoutes) {
+    for (const QString &routeID : qAsConst(listOfRoutes)) {
         QJsonObject singleRouteJSON;
         singleRouteJSON["route_id"]         = routeID;
         singleRouteJSON["route_short_name"] = (*_routes)[routeID].route_short_name;

--- a/gtfs_modules/tripscheduledisplay.cpp
+++ b/gtfs_modules/tripscheduledisplay.cpp
@@ -193,7 +193,7 @@ void TripScheduleDisplay::fillResponseData(QJsonObject &resp)
         resp["start_date"]       = _realTimeProc->getTripStartDate(_tripID);
         resp["start_time"]       = _realTimeProc->getTripStartTime(_tripID);
 
-        for (const GTFS::rtStopTimeUpdate &rtsu : stopTimes) {
+        for (const GTFS::rtStopTimeUpdate &rtsu : qAsConst(stopTimes)) {
             QJsonObject singleStopJSON;
             if (getStatus()->format12h()) {
                 singleStopJSON["arr_time"]  = (rtsu.arrTime.isNull()) ?

--- a/gtfs_modules/upcomingstopservice.cpp
+++ b/gtfs_modules/upcomingstopservice.cpp
@@ -125,7 +125,7 @@ void UpcomingStopService::fillResponseData(QJsonObject &resp)
             resp["stop_id"] = _stopIDs.at(0);
         } else {
             QString stopIDconcat;
-            for (const QString &stopID : _stopIDs) {
+            for (const QString &stopID : qAsConst(_stopIDs)) {
                 stopIDconcat += stopID + " | ";
             }
             resp["stop_id"] = stopIDconcat;
@@ -148,7 +148,7 @@ void UpcomingStopService::fillResponseData(QJsonObject &resp)
             // Fetch the trips
             QJsonArray stopTrips;
             quint32    tripsFoundForRoute = 0;
-            for (const GTFS::StopRecoTripRec &rts : tripsForStopByRouteID[routeID].tripRecos) {
+            for (const GTFS::StopRecoTripRec &rts : qAsConst(tripsForStopByRouteID[routeID].tripRecos)) {
                 GTFS::TripRecStat tripStat = rts.tripStatus;
                 if ((tripStat == GTFS::IRRELEVANT) || (_status->hideTerminatingTripsForNEXNCF() && rts.endOfTrip) ||
                     (_realtimeOnly && (tripStat == GTFS::SCHEDULE || tripStat == GTFS::NOSCHEDULE))) {

--- a/gtfs_process/datagateway.cpp
+++ b/gtfs_process/datagateway.cpp
@@ -129,7 +129,7 @@ void DataGateway::linkStopsTripsRoutes()
     // want to see the full scope of available service per route. What we've done here is to associate stops to routes
     // as well as the # of trips that serve them so the fuller-scale of service is clearer.
     for (const QString &stopTimeTripID : sTimDB.keys()) {
-        for (const StopTimeRec &rec : sTimDB[stopTimeTripID]) {
+        for (const StopTimeRec &rec : qAsConst(sTimDB[stopTimeTripID])) {
             _routes->connectStop(tripDB[stopTimeTripID].route_id, rec.stop_id);
         }
     }

--- a/gtfs_process/gtfsstatus.cpp
+++ b/gtfs_process/gtfsstatus.cpp
@@ -47,7 +47,7 @@ Status::Status(const QString dataRootPath,
     QVector<QVector<QString>> dataStore;
 
     // the feed_info.txt is [unfortunately] not required, so don't assume you have it
-    if (QFileInfo(dataRootPath + "/feed_info.txt").exists()) {
+    if (QFileInfo::exists(dataRootPath + "/feed_info.txt")) {
         qDebug() << "Starting Feed Information Gathering ...";
         // Read in the feed information
         CsvProcess((dataRootPath + "/feed_info.txt").toUtf8(), &dataStore);
@@ -61,13 +61,13 @@ Status::Status(const QString dataRootPath,
         this->version   = (verPos != -1) ? dataStore.at(1).at(verPos) : "";
 
         // Save the start and end dates? Stored as text: YYYYMMDD
-        this->startDate = (sDatePos != -1) ? QDate(dataStore.at(1).at(sDatePos).left  (4)   .toInt(),
-                                                   dataStore.at(1).at(sDatePos).midRef(4, 2).toInt(),
-                                                   dataStore.at(1).at(sDatePos).right (2)   .toInt())
+        this->startDate = (sDatePos != -1) ? QDate(dataStore.at(1).at(sDatePos).left    (4)   .toInt(),
+                                                   dataStore.at(1).at(sDatePos).midRef  (4, 2).toInt(),
+                                                   dataStore.at(1).at(sDatePos).rightRef(2)   .toInt())
                                            : QDate();
-        this->endDate   = (eDatePos != -1) ? QDate(dataStore.at(1).at(eDatePos).left  (4)   .toInt(),
-                                                   dataStore.at(1).at(eDatePos).midRef(4, 2).toInt(),
-                                                   dataStore.at(1).at(eDatePos).right (2)   .toInt())
+        this->endDate   = (eDatePos != -1) ? QDate(dataStore.at(1).at(eDatePos).left    (4)   .toInt(),
+                                                   dataStore.at(1).at(eDatePos).midRef  (4, 2).toInt(),
+                                                   dataStore.at(1).at(eDatePos).rightRef(2)   .toInt())
                                            : QDate();
 
         // Say we processed a record
@@ -131,8 +131,8 @@ Status::Status(const QString dataRootPath,
                          brokenDateParams.at(4).toInt(),
                          brokenDateParams.at(5).toInt());
         frozenAgencyTime = QDateTime(frozenDate, frozenTime, this->serverFeedTZ);
-        qDebug() << endl << "TESTING/DEBUGGING/ANALYSIS MODE: All transaction will be processed as if it is "
-                 << frozenAgencyTime << endl;
+        qDebug() << Qt::endl << "TESTING/DEBUGGING/ANALYSIS MODE: All transaction will be processed as if it is "
+                 << frozenAgencyTime << Qt::endl;
     }
 
     // Show all times with AM/PM indicator instead of standard 24-hour clock

--- a/gtfs_process/gtfsstoptimes.cpp
+++ b/gtfs_process/gtfsstoptimes.cpp
@@ -125,8 +125,8 @@ qint32 StopTimes::computeSecondsLocalNoonOffset(const QString &hhmmssTime)
     }
 
     qint32 firstColon = hhmmssTime.indexOf(":");
-    qint32 hours      = hhmmssTime.left(firstColon).toInt();
-    qint32 seconds    = hhmmssTime.right(2).toInt();
+    qint32 hours      = hhmmssTime.leftRef(firstColon).toInt();
+    qint32 seconds    = hhmmssTime.rightRef(2).toInt();
     qint32 minutes    = hhmmssTime.midRef(firstColon + 1, 2).toInt();
 
     return (hours * 3600 + minutes * 60 + seconds) - s_localNoonSec;

--- a/gtfs_process/operatingday.cpp
+++ b/gtfs_process/operatingday.cpp
@@ -31,7 +31,7 @@ OperatingDay::OperatingDay(const QString dataRootPath, QObject *parent) : QObjec
     QVector<QVector<QString>> dataStore;
 
     // Ingest the calendar information if it exists: NOTE: Either calendar_dates.txt and/or calendar.txt must exist
-    if (QFileInfo(dataRootPath + "/calendar.txt").exists()) {
+    if (QFileInfo::exists(dataRootPath + "/calendar.txt")) {
         qDebug() << "Starting Calendar Information Process ...";
         CsvProcess((dataRootPath + "/calendar.txt").toUtf8(), &dataStore);
         qint8 servicePos, monPos, tuePos, wedPos, thuPos, friPos, satPos, sunPos, sDatePos, eDatePos;
@@ -48,12 +48,12 @@ OperatingDay::OperatingDay(const QString dataRootPath, QObject *parent) : QObjec
             cal.friday       = (dataStore.at(l).at(friPos).toInt() == 1);
             cal.saturday     = (dataStore.at(l).at(satPos).toInt() == 1);
             cal.sunday       = (dataStore.at(l).at(sunPos).toInt() == 1);
-            cal.start_date   = QDate(dataStore.at(l).at(sDatePos).left  (4)   .toInt(),
-                                     dataStore.at(l).at(sDatePos).midRef(4, 2).toInt(),
-                                     dataStore.at(l).at(sDatePos).right (2)   .toInt());
-            cal.end_date     = QDate(dataStore.at(l).at(eDatePos).left  (4)   .toInt(),
-                                     dataStore.at(l).at(eDatePos).midRef(4, 2).toInt(),
-                                     dataStore.at(l).at(eDatePos).right (2)   .toInt());
+            cal.start_date   = QDate(dataStore.at(l).at(sDatePos).left    (4)   .toInt(),
+                                     dataStore.at(l).at(sDatePos).midRef  (4, 2).toInt(),
+                                     dataStore.at(l).at(sDatePos).rightRef(2)   .toInt());
+            cal.end_date     = QDate(dataStore.at(l).at(eDatePos).left    (4)   .toInt(),
+                                     dataStore.at(l).at(eDatePos).midRef  (4, 2).toInt(),
+                                     dataStore.at(l).at(eDatePos).rightRef(2)   .toInt());
             this->calendarDb[dataStore.at(l).at(servicePos)] = cal;
         }
     }
@@ -61,7 +61,7 @@ OperatingDay::OperatingDay(const QString dataRootPath, QObject *parent) : QObjec
     dataStore.clear();
 
     // Ingest the calednar_dates (override) information (again, see above, it is possible for at least 1 to exist
-    if (QFileInfo(dataRootPath + "/calendar_dates.txt").exists()) {
+    if (QFileInfo::exists(dataRootPath + "/calendar_dates.txt")) {
         CsvProcess((dataRootPath + "/calendar_dates.txt").toUtf8(), &dataStore);
         qint8 idPos, datePos, exceptionPos;
         calendarDatesCSVOrder(dataStore.at(0), idPos, datePos, exceptionPos);
@@ -70,9 +70,9 @@ OperatingDay::OperatingDay(const QString dataRootPath, QObject *parent) : QObjec
             CalDateRec cd;
             cd.service_id     = dataStore.at(l).at(idPos);
             cd.exception_type = dataStore.at(l).at(exceptionPos).toShort();
-            cd.date           = QDate(dataStore.at(l).at(datePos).left  (4)   .toInt(),
-                                      dataStore.at(l).at(datePos).midRef(4, 2).toInt(),
-                                      dataStore.at(l).at(datePos).right (2)   .toInt());
+            cd.date           = QDate(dataStore.at(l).at(datePos).left    (4)   .toInt(),
+                                      dataStore.at(l).at(datePos).midRef  (4, 2).toInt(),
+                                      dataStore.at(l).at(datePos).rightRef(2)   .toInt());
             this->calendarDateDb[dataStore.at(l).at(idPos)].push_back(cd);
         }
     }
@@ -260,8 +260,8 @@ QString OperatingDay::serializeAddedServiceDates(const QString &serviceName) con
     QString calDates;
 
     if (this->calendarDateDb.contains(serviceName)) {
-        QVector<CalDateRec> rec = this->calendarDateDb[serviceName];
-        for (CalDateRec cdr : rec) {
+        const QVector<CalDateRec> &rec = this->calendarDateDb[serviceName];
+        for (const CalDateRec &cdr : rec) {
             if (cdr.exception_type == 1)
                 calDates += cdr.date.toString("ddMMMyyyy") + " ";
         }
@@ -277,8 +277,8 @@ bool OperatingDay::serviceAddedOnOtherDates(const QString &serviceName) const
     qint32 nbAddedDates = 0;
 
     if (this->calendarDateDb.contains(serviceName)) {
-        QVector<CalDateRec> rec = this->calendarDateDb[serviceName];
-        for (CalDateRec cdr : rec)
+        const QVector<CalDateRec> &rec = this->calendarDateDb[serviceName];
+        for (const CalDateRec &cdr : rec)
             if (cdr.exception_type == 1)
                 ++nbAddedDates;
     }
@@ -291,8 +291,8 @@ QString OperatingDay::serializeNoServiceDates(const QString &serviceName) const
     QString calDates;
 
     if (this->calendarDateDb.contains(serviceName)) {
-        QVector<CalDateRec> rec = this->calendarDateDb[serviceName];
-        for (CalDateRec cdr : rec) {
+        const QVector<CalDateRec> &rec = this->calendarDateDb[serviceName];
+        for (const CalDateRec &cdr : rec) {
             if (cdr.exception_type == 2)
                 calDates += cdr.date.toString("ddMMMyyyy") + " ";
         }
@@ -308,8 +308,8 @@ bool OperatingDay::serviceRemovedOnDates(const QString &serviceName) const
     qint32 nbExemptedDates = 0;
 
     if (this->calendarDateDb.contains(serviceName)) {
-        QVector<CalDateRec> rec = this->calendarDateDb[serviceName];
-        for (CalDateRec cdr : rec)
+        const QVector<CalDateRec> &rec = this->calendarDateDb[serviceName];
+        for (const CalDateRec &cdr : rec)
             if (cdr.exception_type == 2)
                 ++nbExemptedDates;
     }

--- a/gtfs_process/tripstopreconciler.cpp
+++ b/gtfs_process/tripstopreconciler.cpp
@@ -90,7 +90,7 @@ void TripStopReconciler::getTripsByRoute(QHash<QString, StopRecoRouteRec> &route
     QHash<QString, StopRecoRouteRec> fullTrips;
 
     // For every stop requested, find all relevant trips
-    for (const QString &stopID : _stopIDs) {
+    for (const QString &stopID : qAsConst(_stopIDs)) {
 
     // Retrieve all the trips that could service the stop (from yesterday, today, and tomorrow service days)
     for (const QString &routeID : (*sStops)[stopID].stopTripsRoutes.keys()) {
@@ -245,7 +245,7 @@ void TripStopReconciler::getTripsByRoute(QHash<QString, StopRecoRouteRec> &route
         QHash<QString, QVector<QPair<QString, quint32>>> addedTrips;
         rActiveFeed->getAddedTripsServingStop(stopID, addedTrips);
         for (const QString &routeID : addedTrips.keys()) {
-            for (const QPair<QString, quint32> &tripAndIndex : addedTrips[routeID]) {
+            for (const QPair<QString, quint32> &tripAndIndex : qAsConst(addedTrips[routeID])) {
                 // Make a new tripRecord so we have a place to add current trip information
                 StopRecoTripRec tripRecord;
 

--- a/gtfs_realtime/gtfsrealtimefeed.cpp
+++ b/gtfs_realtime/gtfsrealtimefeed.cpp
@@ -78,7 +78,7 @@ RealTimeTripUpdate::RealTimeTripUpdate(const QByteArray   &gtfsRealTimeData,
     _tripUpdate.ParseFromArray(gtfsRealTimeData, gtfsRealTimeData.size());
 
     if (displayBufferInfo) {
-        qDebug() << "  (RTTU) GTFS-Realtime : LIVE Protobuf: " << _tripUpdate.ByteSize()
+        qDebug() << "  (RTTU) GTFS-Realtime : LIVE Protobuf: " << _tripUpdate.ByteSizeLong()
                  << "bytes consisting of" << _tripUpdate.entity_size() << "real-time records.";
     }
 
@@ -369,7 +369,7 @@ void RealTimeTripUpdate::tripStopActualTime(const QString              &tripID,
     fillStopTimesForTrip(TRIPID_RECONCILE, -1, tripID, agencyTZ, serviceDate, tripTimes, rtStopTimes);
 
     // Pick out the stop time relevant to the requested stop and return it
-    for (const rtStopTimeUpdate &rtst : rtStopTimes) {
+    for (const rtStopTimeUpdate &rtst : qAsConst(rtStopTimes)) {
         if (((rtst.stopSequence != -1) && (rtst.stopSequence == stopSeq) && (rtst.stopID == stop_id)) ||
              (rtst.stopID == stop_id)) {
             realArrTimeUTC = rtst.arrTime;
@@ -459,7 +459,7 @@ void RealTimeTripUpdate::fillStopTimesForTrip(rtUpdateMatch               realTi
                 // (should also enforce that the stop id matches the trip update contents)
                 QString stopIdRT = QString::fromStdString(tri.stop_time_update(stUpdIdx).stop_id());
                 if (tri.stop_time_update(stUpdIdx).has_stop_sequence() &&
-                    stopRec.stop_sequence == tri.stop_time_update(stUpdIdx).stop_sequence()) {
+                    static_cast<quint32>(stopRec.stop_sequence) == tri.stop_time_update(stUpdIdx).stop_sequence()) {
                     stu.stopSequence = stopRec.stop_sequence;
                     break;
                 } else if ((!tri.stop_time_update(stUpdIdx).has_stop_sequence() || _loosenStopSeqEnf) &&
@@ -788,9 +788,9 @@ void RealTimeTripUpdate::showProtobufData() const
     google::protobuf::TextFormat::PrintToString(_tripUpdate, &data);
     qDebug() << "GTFS-Realtime : LOCAL DEBUGGING MODE";
     qDebug() << "-----[ CONTENTS ]------------------------------------------------------------------------------------";
-    qDebug() << data.c_str() << endl
+    qDebug() << data.c_str() << Qt::endl
              << "-----------------------------------------------------------------------[ END PROTOBUF CONTENTS ]-----";
-    qDebug() << "Protobuf: " << _tripUpdate.ByteSize() << " bytes" << endl;
+    qDebug() << "Protobuf: " << _tripUpdate.ByteSizeLong() << " bytes" << Qt::endl;
     qDebug() << "Processing _tripUpdate.entity_size() = " << _tripUpdate.entity_size() << "real-time records.";
 }
 

--- a/gtfsproc/gtfsrequestprocessor.cpp
+++ b/gtfsproc/gtfsrequestprocessor.cpp
@@ -222,7 +222,7 @@ QDate GtfsRequestProcessor::determineServiceDay(const QString &userReq, QString 
 qint32 GtfsRequestProcessor::determineMinuteRange(const QString &userReq, QString &remUserQuery)
 {
     // First space determines the amount of time to request
-    qint32 futureMinutes = userReq.left(userReq.indexOf(" ")).toInt();
+    qint32 futureMinutes = userReq.leftRef(userReq.indexOf(" ")).toInt();
     remUserQuery = userReq.mid(userReq.indexOf(" ") + 1);
     return futureMinutes;
 }

--- a/gtfsproc/servegtfs.cpp
+++ b/gtfsproc/servegtfs.cpp
@@ -106,7 +106,7 @@ ServeGTFS::~ServeGTFS()
 void ServeGTFS::displayDebugging() const
 {
     const GTFS::Status *data = GTFS::DataGateway::inst().getStatus();
-    qDebug() << endl << "[ GTFS Static Data Information ]";
+    qDebug() << Qt::endl << "[ GTFS Static Data Information ]";
     qDebug() << "Recs Loaded . . . ." << data->getRecordsLoaded();
     qDebug() << "Server Start Time ." << data->getServerStartTimeUTC();
     qDebug() << "Feed Publisher  . ." << data->getPublisher();
@@ -114,7 +114,7 @@ void ServeGTFS::displayDebugging() const
     qDebug() << "Feed Language . . ." << data->getLanguage();
     qDebug() << "Feed Start Date . ." << data->getStartDate().toString("dd-MMM-yyyy");
     qDebug() << "Feed End Date . . ." << data->getEndDate().toString("dd-MMM-yyyy");
-    qDebug() << "Feed Version  . . ." << data->getVersion() << endl;
+    qDebug() << "Feed Version  . . ." << data->getVersion() << Qt::endl;
 }
 
 void ServeGTFS::incomingConnection(qintptr descriptor)

--- a/gtfsproc/server_main.cpp
+++ b/gtfsproc/server_main.cpp
@@ -33,14 +33,14 @@ int main(int argc, char *argv[])
      */
     QCoreApplication a(argc, argv);
     QCoreApplication::setApplicationName("GtfsProc");
-    QCoreApplication::setApplicationVersion("1.8c");
+    QCoreApplication::setApplicationVersion("1.8d");
 
     QTextStream console(stdout);
     QString appName = QCoreApplication::applicationName();
     QString appVers = QCoreApplication::applicationVersion();
 
     console << appName.remove("\"") << " version " << appVers.remove("\"")
-            << " - Running on Process ID: " << QCoreApplication::applicationPid() << endl << endl;
+            << " - Running on Process ID: " << QCoreApplication::applicationPid() << Qt::endl << Qt::endl;
 
     /*
      * Command Line Parsing
@@ -197,10 +197,10 @@ int main(int argc, char *argv[])
      * BEGIN LISTENING FOR CONNECTIONS
      */
     if (gtfsRequestServer.listen(QHostAddress::Any, portNum)) {
-        console << "SERVER STARTED - READY TO ACCEPT INCOMING CONNECTIONS" << endl << endl;
+        console << "SERVER STARTED - READY TO ACCEPT INCOMING CONNECTIONS" << Qt::endl << Qt::endl;
     } else {
         console << gtfsRequestServer.errorString();
-        console << endl << "(!) COULD NOT START SERVER - SEE ERROR STRING ABOVE" << endl;
+        console << Qt::endl << "(!) COULD NOT START SERVER - SEE ERROR STRING ABOVE" << Qt::endl;
         return 1;
     }
 

--- a/tcp/tcpconnection.cpp
+++ b/tcp/tcpconnection.cpp
@@ -22,9 +22,9 @@ void TcpConnection::setSocket(QTcpSocket *socket)
     connect(m_socket,&QTcpSocket::readyRead, this, &TcpConnection::readyRead);
     connect(m_socket,&QTcpSocket::bytesWritten, this, &TcpConnection::bytesWritten);
     connect(m_socket,&QTcpSocket::stateChanged, this, &TcpConnection::stateChanged);
-    connect(m_socket,static_cast<void (QTcpSocket::*)(QAbstractSocket::SocketError)>(&QTcpSocket::error),
+    connect(m_socket,
+            static_cast<void (QTcpSocket::*)(QAbstractSocket::SocketError)>(&QTcpSocket::errorOccurred),
             this, &TcpConnection::error);
-
 }
 
 QTcpSocket *TcpConnection::getSocket()

--- a/tcp/tcpconnections.cpp
+++ b/tcp/tcpconnections.cpp
@@ -105,7 +105,10 @@ void TcpConnections::accept(qintptr handle, TcpConnection *connection)
     // connect(socket,static_cast<void (QTcpSocket::*)(QAbstractSocket::SocketError)>(&QTcpSocket::error),this,&TcpConnections::error);
 
     connect(socket,&QTcpSocket::disconnected, this, &TcpConnections::disconnected);
-    connect(socket,static_cast<void (QTcpSocket::*)(QAbstractSocket::SocketError)>(&QTcpSocket::error),this,&TcpConnections::error);
+    connect(socket,
+            static_cast<void (QTcpSocket::*)(QAbstractSocket::SocketError)>(&QTcpSocket::errorOccurred),
+            this,
+            &TcpConnections::error);
 
     connection->moveToThread(QThread::currentThread());
     connection->setSocket(socket);

--- a/tests/CTTransit/stop_sequence_vs_stop_id_matching.test
+++ b/tests/CTTransit/stop_sequence_vs_stop_id_matching.test
@@ -62,7 +62,7 @@ to a stop in NEX/NCF.
             "url": "http://www.cttransit.com"
         }
     ],
-    "application": "GtfsProc 1.8c",
+    "application": "GtfsProc 1.8d",
 *   "appuptime_sec": 6,
 *   "dataloadtime_ms": 2830,
     "error": 0,

--- a/tests/CTTransit/trips_before_and_after_midnight.test
+++ b/tests/CTTransit/trips_before_and_after_midnight.test
@@ -59,7 +59,7 @@ case proves that both types of trips are visible to a single stop that is served
             "url": "http://www.cttransit.com"
         }
     ],
-    "application": "GtfsProc 1.8c",
+    "application": "GtfsProc 1.8d",
 *   "appuptime_sec": 16,
 *   "dataloadtime_ms": 2736,
     "error": 0,

--- a/tests/MBTA/after_midnights.test
+++ b/tests/MBTA/after_midnights.test
@@ -30,7 +30,7 @@ and canceled).
             "url": "http://www.mbta.com"
         }
     ],
-    "application": "GtfsProc 1.8c",
+    "application": "GtfsProc 1.8d",
 *   "appuptime_sec": 15,
 *   "dataloadtime_ms": 8034,
     "error": 0,

--- a/tests/RIPTA/trips_midnight_extrapolation.test
+++ b/tests/RIPTA/trips_midnight_extrapolation.test
@@ -27,7 +27,7 @@ offset prediction in a trip can be extrapolated from the last known offset.
             "url": "http://www.ripta.com/"
         }
     ],
-    "application": "GtfsProc 1.8c",
+    "application": "GtfsProc 1.8d",
 *   "appuptime_sec": 57,
 *   "dataloadtime_ms": 807,
     "error": 0,

--- a/tests/SEPTA_Rail/trips_before_and_after_midnight.test
+++ b/tests/SEPTA_Rail/trips_before_and_after_midnight.test
@@ -28,7 +28,7 @@ published with an offset, the remaining stops in a trip are assumed to have the 
             "url": "http://www.septa.org"
         }
     ],
-    "application": "GtfsProc 1.8c",
+    "application": "GtfsProc 1.8d",
 *   "appuptime_sec": 9,
 *   "dataloadtime_ms": 8,
     "error": 0,


### PR DESCRIPTION
In the scope of the new Debian 11 release, as Debian Stable is the reference compilation platform for GtfsProc, ensure that any fallout coming from the upgrade to Qt 5.15.2 is dealt with. The following steps were performed:

- Fixed `endl` vs `Qt::endl` deprecation warnings.
- Fixed signed-ness comparison warning in the laziest way possible as "it should not happen" according to the GTFS specification.
- Performed (where it made sense) suggested clazy-recommended fixes. Some proposals were impossible due to needing the hash key information it claimed to not be used.
- Promote to GtfsProc 1.8d - only technical changes, no functional changes.
- Update non-regression test cases to reflect new version numbering.
- Updated installation / compilation steps to reflect Debian package names.