### PR TITLE
Version 2.2.0: EES/EER Module Created

### DIFF
--- a/GtfsProc_Documentation.html
+++ b/GtfsProc_Documentation.html
@@ -2,7 +2,7 @@
 <head>
 </head>
     <meta charset="UTF-8">
-    <title>GtfsProc Server and Transaction Documentation (Version 2.1.0)</title>
+    <title>GtfsProc Server and Transaction Documentation (Version 2.2.0)</title>
     <style>
         .fixed {
             font-family: monospace;
@@ -36,7 +36,7 @@
     GtfsProc was written almost entirely in the Qt Application Framework. The TCP server code comes from Bryan Cairns of VoidRealms. See http://www.voidrealms.com/ for the original source and license. The GtfsProc code is written by Daniel Brook (danb358 {AT} gmail {DOT} com), (c) 2018-2023, GPL v 3.
 </p>
 <p>
-    This is the documentation for <b>GtfsProc Version 2.1.0 (02-Aug-2023)</b>
+    This is the documentation for <b>GtfsProc Version 2.2.0 (27-Aug-2023)</b>
 </p>
 
 <h1>Server Options</h1>
@@ -79,7 +79,7 @@
     </li>
 </ol>
 <div class="fixed">
-GtfsProc version 2.1.0 - Running on Process ID: 22112<br>
+GtfsProc version 2.2.0 - Running on Process ID: 22112<br>
 <br>
 Starting Feed Information Gathering ... <br>
 Starting Agency Gathering ...<br>
@@ -149,7 +149,7 @@ SERVER STARTED - READY TO ACCEPT INCOMING CONNECTIONS<br>
     This will connect to a server on localhost which receives requests on TCP port 5000. Upon startup, a small help window will display the supported transactions. If you resize the terminal window at all, the ncurses-based window geometry detection must be refreshed / "reinitialized" using "HOM" again.
 </p>
 <div class="fixed">
-GTFS Interactive Data Console -- Version: 0.1 <br>
+GTFS Interactive Data Console -- Version: 0.2 <br>
 <br>
 [ System Information ] <br>
 SDS: Backend system and data load status <br>
@@ -170,6 +170,10 @@ TRD: List of trips serving a route_id on a date <br>
 TSD: List of trips serving a stop_id on a date <br>
 NEX: List upcoming trips serving a stop_id within a number of minutes <br>
 <br>
+[ Service Connecting Stops ] <br>
+SBS: Service between 2 stops, scheduled <br>
+EES: End-to-end connecting services with times <br>
+EER: End-to-end connecting services (real-time data only) <br>
 Reinitialize the display with 'HOM', quit using 'BYE' <br>
 <br>
 %
@@ -2891,6 +2895,28 @@ NEX {look-ahead minutes} {stopID1}|{stopID2}|...|{stopIDn}
     </tr>
     <tr>
         <td class="fixed">
+            route_id
+        </td>
+        <td class="fixed">
+            string
+        </td>
+        <td>
+            Route ID for the trip ID
+        </td>
+    </tr>
+    <tr>
+        <td class="fixed">
+            stop_id
+        </td>
+        <td class="fixed">
+            string
+        </td>
+        <td>
+            Stop ID for the stop that the trip actually serves (like a unique platform within a parent stop)
+        </td>
+    </tr>
+    <tr>
+        <td class="fixed">
             dep_time
         </td>
         <td class="fixed">
@@ -3110,6 +3136,17 @@ NCF {look-ahead minutes} {stopID1}|{stopID2}|...|{stopIDn}
         </td>
         <td>
             Stop ID of the stop requested, or the parent station, or a “|” delimited list of all stop IDs requested
+        </td>
+    </tr>
+    <tr>
+        <td class="fixed">
+            static_data_modif
+        </td>
+        <td class="fixed">
+            string
+        </td>
+        <td>
+            Last-modified time and date of the GTFS Static Dataset for the whole transit agency.
         </td>
     </tr>
     <tr>
@@ -3699,6 +3736,87 @@ Possible error values:
         </td>
     </tr>
 
+</table>
+
+<h3>End-to-End Journey Travel and Transfer Times</h3>
+<p>Given a list of origin and destination stop IDs split by connection times in minutes, returns the upcoming trips (and downstream connections if requested) that will travel from end-to-end.</p>
+<p>A single trip origin/destination may be specified, but if additional legs are needed, they'll have to be separated by a connection "penalty" time in minutes.</p>
+<h4>Request Format</h4>
+<p>
+Scheduled and real-time data:
+<ul>
+    <li>EES {look-ahead minutes} {stopIDori1}|{stopIDdes1}</li>
+    <li>EES {look-ahead minutes} {stopIDori1}|{stopIDdes1}|{connectTime1}|{stopIDori2}|{stopIDdes2}|...</li>
+</ul>
+Only trips that have predictions (real-time data):
+<ul>
+    <li>EER {look-ahead minutes} {stopIDori1}|{stopIDdes1}</li>
+    <li>EER {look-ahead minutes} {stopIDori1}|{stopIDdes1}|{connectTime1}|{stopIDori2}|{stopIDdes2}|...</li>
+</ul>
+
+</p>
+<h4>Response Format</h4>
+<p>
+    The ‘message_type’ is “E2E”.<br>
+    Possible error values:
+    <ul>
+        <li>0: Success</li>
+        <li>901: Incorrect number of arguments</li>
+        <li>902: Non-numeric or negative value requested in a connection time field</li>
+        <li>903: One of the stop IDs requested does not exist in the dataset</li>
+    </ul>
+    <b>The trip array contents are identical to "NEX" and "NCF" messages:</b>
+</p>
+<table class="fieldDocumentation">
+    <tr>
+        <th>Field</th>
+        <th>Type</th>
+        <th>Description</th>
+    </tr>
+    <tr>
+        <td class="fixed">
+            realtime_age_sec
+        </td>
+        <td class="fixed">
+            integer
+        </td>
+        <td>
+            Age of the real-time data used to compute the arrival/departure times (if available)
+        </td>
+    </tr>
+    <tr>
+        <td class="fixed">
+            static_data_modif
+        </td>
+        <td class="fixed">
+            string
+        </td>
+        <td>
+            Last-modified time and date of the GTFS Static Dataset for the whole transit agency.
+        </td>
+    </tr>
+    <tr>
+        <td class="fixed">
+            <b>stops<b>
+        </td>
+        <td class="fixed">
+            object
+        </td>
+        <td>
+            Associative array of stop IDs with their stop_desc and stop_name fields from the static dataset. Includes every stop that shows up in the trips array for this message.
+        </td>
+    </tr>
+    <tr>
+        <td class="fixed">
+            <b>trips</b>
+        </td>
+        <td class="fixed">
+            array
+        </td>
+        <td>
+            An array (sorted by the departure time of the first leg of a trip sequence) of all recommended journeys. Each element of the array contains an array with 2 items: the origin and destination stop (identical to a NEX/NCF trip response).
+        </td>
+    </tr>
 </table>
 
 <!--

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -42,3 +42,8 @@ Several individual moving parts will help in this process:
    you like to keep stuff running in perpetuity.
     -or-
    Create a SysV-style init or systemd init script to have it load on system startup?
+
+Build Issues?
+1) At least on Arch / Manjaro, your Protocol Buffer setup requires explicit linking of
+   libasl, so if you're having issues on that distribution, go to gtfs_realtime.pri and
+   do the necessary uncommenting.

--- a/README.md
+++ b/README.md
@@ -34,13 +34,9 @@ agencies were tested and work with this agent:
 - RTC Southern Nevada
 
 Agencies with realtime data have some differences in feed details, and the GtfsProc server can be started with several
-options to work around these differences (see the GtfsProc_Documentation.html file for details). Testing on the following
-agencies with realtime data revealed the following overrides were necessary to correctly calculate trip predictions:
-- MBTA: default options are fine (MBTA data was used at the original reference)
-- RIPTA: use '-l 1' (less-strict realtime trip start-time enforcement)
-- CT Transit: use '-r 90 -l 1 -q' (refresh at 90 seconds, disable stop sequence matching)
-- SEPTA: use '-l 2' (no date enforcement)
-- RTC Southern Nevada: use '-l 2'
+options to work around these differences (see the GtfsProc_Documentation.html file for details). Depending on your
+agency and how they publish real-time data, you'll want to experiment with: override options (-z), matching real-time
+schedules with stop IDs and/or sequence numbers (-l 0/1/2) to show the most number of predicted trips.
 
 Before finalizing any changes, be sure to run the non-regression tests under tests/*. You need Python (3) installed and
 simply need to:

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,10 +1,21 @@
-THIS RELEASE: Version 2.1.1
+THIS RELEASE: Version 2.2.0
 ---------------------------
-- Fixed a wrong order-of-arguments bug in constructing RealTimeTripUpdate objects (trace parameter
-  and all-skipped-is-canceled flag were stepping on each other)
+- Created EES and EER transactions to show arrival and departure times of entire trips with
+  connecting routes and specified transfer fimes.
+    - EES: End-to-End Service with scheduled and real-time data
+    - EER: End-to-End Service with trips using ONLY real-time data
+- Added stop ID, route ID, name information to NEX/NCF trip payloads
+- Added skip column to real-time trips in the terminal client
+- Fixed real-time trip stop sequence matching to also take into effect the stop ID (not just the
+  sequence number) because the "-q" option shuold have been evaluated first when doing comparisons.
 
 
 PREVIOUS RELEASES:
+Version 2.1.1
+-------------
+- Fixed a wrong order-of-arguments bug in constructing RealTimeTripUpdate objects (trace parameter
+  and all-skipped-is-canceled flag were stepping on each other)
+
 Version 2.1.0
 -------------
 - Created the notion of Override Lists, which are Boolean process flags that (will) allow for the

--- a/client_cli/client_main.cpp
+++ b/client_cli/client_main.cpp
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
     QCoreApplication a(argc, argv);
 
     QCoreApplication::setApplicationName("GtfsProc_Client");
-    QCoreApplication::setApplicationVersion("0.1");
+    QCoreApplication::setApplicationVersion("0.2");
 
     QCommandLineParser parser;
     parser.setApplicationDescription("GtfsProc Debugging Console and Data Access Client");

--- a/client_cli/structureddisplay.cpp
+++ b/client_cli/structureddisplay.cpp
@@ -1,6 +1,6 @@
 /*
  * GtfsProc_Server
- * Copyright (C) 2018-2021, Daniel Brook
+ * Copyright (C) 2018-2023, Daniel Brook
  *
  * This file is part of GtfsProc.
  *
@@ -89,7 +89,12 @@ void Display::displayWelcome()
            << "[ Data Lookup for Specific Date ]" << Qt::endl
            << "TRD: List of trips serving a route_id on a date" << Qt::endl
            << "TSD: List of trips serving a stop_id on a date" << Qt::endl
-           << "NEX: List upcoming trips serving a stop_id within a number of minutes" << Qt::endl
+           << "NEX/NCF: List upcoming trips serving stop_id within a number of minutes" << Qt::endl
+           << Qt::endl
+           << "[ Service Connecting Stops ]" << Qt::endl
+           << "SBS: Service between 2 stops, scheduled" << Qt::endl
+           << "EES: End-to-end connecting services with times" << Qt::endl
+           << "EER: End-to-end connecting services (real-time data only)" << Qt::endl
            << Qt::endl
            << "Reinitialize the display with 'HOM', quit using 'BYE'"
            << Qt::endl << Qt::endl;

--- a/gtfs_modules/endtoendtrips.cpp
+++ b/gtfs_modules/endtoendtrips.cpp
@@ -1,0 +1,314 @@
+/*
+ * GtfsProc_Server
+ * Copyright (C) 2023, Daniel Brook
+ *
+ * This file is part of GtfsProc.
+ *
+ * GtfsProc is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * GtfsProc is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with GtfsProc.
+ * If not, see <https://www.gnu.org/licenses/>.
+ *
+ * See included LICENSE.txt file for full license.
+ */
+
+#include "endtoendtrips.h"
+
+#include "upcomingstopservice.h"
+
+#include <QJsonObject>
+#include <QJsonArray>
+
+namespace GTFS {
+
+EndToEndTrips::EndToEndTrips(qint32 futureMinutes, bool realtimeOnly, QList<QString> argList)
+    : StaticStatus(),
+      _futureMinutes(futureMinutes),
+      _realtimeOnly(realtimeOnly),
+      _tripCnx(argList),
+      _rtData(false)
+{
+    // Realtime Data Determination
+    RealTimeGateway::inst().realTimeTransactionHandled();
+    _realTimeProc = GTFS::RealTimeGateway::inst().getActiveFeed();
+    if (_realTimeProc != nullptr) {
+        _rtData = true;
+    }
+
+    // Static Datasets for the TripStopReconciler
+    _status    = GTFS::DataGateway::inst().getStatus();
+    _service   = GTFS::DataGateway::inst().getServiceDB();
+    _stops     = GTFS::DataGateway::inst().getStopsDB();
+    _parentSta = GTFS::DataGateway::inst().getParentsDB();
+    _routes    = GTFS::DataGateway::inst().getRoutesDB();
+    _stopTimes = GTFS::DataGateway::inst().getStopTimesDB();
+    _tripDB    = GTFS::DataGateway::inst().getTripsDB();
+
+    // Override the service date if in the fixed debugging date mode
+    if (!_status->getOverrideDateTime().isNull()) {
+        _systemDate = _status->getOverrideDateTime().date();
+    } else {
+        _systemDate = getAgencyTime().date();
+    }
+}
+
+void EndToEndTrips::fillResponseData(QJsonObject &resp)
+{
+    // Supported arguments analysis
+    // 2: origin and destination, no transfer
+    // 5: 1 connection: [0] and [1] first leg ori/des, [2] connection time, [3] and [4] second leg ori/des
+    // 8: 2 connections O1=[0], D1=[1], Connect=[2], O2=[3], D2=[4], Connect=[5], O3=[6], D3=[7]
+    // 11, 14, 17, etc.!
+    quint32 argLength = _tripCnx.length();
+    if (argLength != 2 && (argLength - 2) % 3 != 0) {
+        fillProtocolFields("E2E", 901, resp);  // Wrong number of arguments
+        return;
+    }
+
+    // Ensure the validity of input arguments
+    for (quint32 i = 0; i < argLength; ++i) {
+        if (i >= 2 && (i - 2) % 3 == 0) {
+            bool numberOK;
+            qint32 cnxTimeMin = _tripCnx[i].toInt(&numberOK);
+            if (!numberOK || cnxTimeMin < 0) {
+                fillProtocolFields("E2E", 902, resp);  // Non-numeric OR negative connection time specified
+                return;
+            }
+        } else {
+            if (!_stops->contains(_tripCnx[i])) {
+                fillProtocolFields("E2E", 903, resp);  // Non-existent stop id specified
+                return;
+            }
+        }
+    }
+
+    // Store dataset modification times (used by long-running clients to see if new route details should be retrieved)
+    resp["static_data_modif"] = _status->getStaticDatasetModifiedTime().toString("dd-MMM-yyyy hh:mm:ss t");
+
+    if (_rtData) {
+        QDateTime activeFeedTime = _realTimeProc->getFeedTime();
+        if (activeFeedTime.isNull()) {
+            resp["realtime_age_sec"] = "-";
+        } else {
+            resp["realtime_age_sec"] = activeFeedTime.secsTo(getAgencyTime());
+        }
+    }
+
+    // Get upcoming arrivals like a normal NCF request ... BUT: filter out trips that do not pickup at origin and
+    // drop-off at destination. Filter out anything that skips either stop, as well.
+    QVector<QVector<StopRecoTripRec>> travelRecoTimes;
+    QSet<qsizetype>                   deadRecos;
+    fillRecoOD(0, 0, _tripCnx[0], _tripCnx[1], deadRecos, travelRecoTimes);
+
+    if (argLength > 2) {
+        quint32 totalConnections = (argLength - 2) / 3;
+        for (quint32 connection = 0; connection < totalConnections; ++connection) {
+            qint32 cnxTime = _tripCnx[2 + connection * 3].toInt();
+            QString originStopId = _tripCnx[3 + connection * 3];
+            QString destinationStopId = _tripCnx[4 + connection * 3];
+            fillRecoOD(connection + 1, cnxTime, originStopId, destinationStopId, deadRecos, travelRecoTimes);
+        }
+    }
+
+    // Get stop information from every stop encountered - then save them to JSON
+    QSet<QString> stopIds;
+    for (qsizetype r = 0; r < travelRecoTimes.length(); ++r) {
+        if (deadRecos.contains(r)) {
+            continue;
+        }
+        for (const StopRecoTripRec &srtr : travelRecoTimes[r]) {
+            stopIds.insert(srtr.stopID);
+        }
+    }
+    QJsonObject stopsAssocArray;
+    for (const QString &stopId : stopIds) {
+        QJsonObject stopDetails;
+        stopDetails["stop_desc"] = (*_stops)[stopId].stop_desc;
+        stopDetails["stop_name"] = (*_stops)[stopId].stop_name;
+        stopsAssocArray[stopId] = stopDetails;
+    }
+    resp["stops"] = stopsAssocArray;
+
+    // Place into JSON style output now that it is sorted together by wait time
+    QJsonArray stopRouteArray;
+    for (qsizetype r = 0; r < travelRecoTimes.length(); ++r) {
+        if (deadRecos.contains(r)) {
+            continue;
+        }
+
+        QJsonArray connectionArray;
+        for (const StopRecoTripRec &srtr : travelRecoTimes[r]) {
+            QJsonObject stopTripItem;
+            UpcomingStopService::fillTripData(srtr, stopTripItem, getStatus()->format12h(),
+                                              (*_tripDB)[srtr.tripID].trip_short_name);
+            connectionArray.push_back(stopTripItem);
+        }
+        stopRouteArray.push_back(connectionArray);
+    }
+
+    // Attach the routes and trips collections
+    resp["trips"]  = stopRouteArray;
+
+    fillProtocolFields("E2E", 0, resp);
+}
+
+void EndToEndTrips::fillRecoOD(quint8                             legNum,
+                               quint32                            xferMin,
+                               QString                            oriStopId,
+                               QString                            desStopId,
+                               QSet<qsizetype>                   &deadRecos,
+                               QVector<QVector<StopRecoTripRec>> &allRecos)
+{
+    QHash<QString, GTFS::StopRecoRouteRec> tripsForOriStopByRouteID;
+    qint32 originLookaheadTime = (legNum == 0) ? _futureMinutes : 720;
+    QList<QString> startStopIds;
+    if (_parentSta->contains(oriStopId)) {
+        startStopIds = (*_parentSta)[oriStopId].toList();
+    } else {
+        startStopIds.push_back(oriStopId);
+    }
+    GTFS::TripStopReconciler oriStopTripLoader(startStopIds, _rtData, _systemDate, getAgencyTime(), originLookaheadTime,
+                                               _status, _service, _stops, _routes, _tripDB, _stopTimes, _realTimeProc);
+    oriStopTripLoader.getTripsByRoute(tripsForOriStopByRouteID);
+
+    QHash<QString, GTFS::StopRecoRouteRec> tripsForDesStopByRouteID;
+    QList<QString> destStopIds;
+    if (_parentSta->contains(desStopId)) {
+        destStopIds = (*_parentSta)[desStopId].toList();
+    } else {
+        destStopIds.push_back(desStopId);
+    }
+    GTFS::TripStopReconciler desStopTripLoader(destStopIds, _rtData, _systemDate, getAgencyTime(), 720,  // 12 hour L-A
+                                               _status, _service, _stops, _routes, _tripDB, _stopTimes, _realTimeProc);
+    desStopTripLoader.getTripsByRoute(tripsForDesStopByRouteID);
+
+    // Only work with trips the hit both stops appropriately
+    QHash<QString, GTFS::StopRecoRouteRec> tripsForBothStopsOri;
+    QHash<QString, GTFS::StopRecoRouteRec> tripsForBothStopsDes;
+    for (const QString &routeID : tripsForOriStopByRouteID.keys()) {
+        tripsForBothStopsOri[routeID] = tripsForOriStopByRouteID[routeID];
+        tripsForBothStopsOri[routeID].tripRecos.clear();
+        tripsForBothStopsDes[routeID] = tripsForDesStopByRouteID[routeID];
+        tripsForBothStopsDes[routeID].tripRecos.clear();
+
+        for (qsizetype o = 0; o < tripsForOriStopByRouteID[routeID].tripRecos.length(); ++o) {
+            for (qsizetype d = 0; d < tripsForDesStopByRouteID[routeID].tripRecos.length(); ++d) {
+                //
+                // FIXME: probably more criteria for matching but this gets us started?
+                //
+                if (( //tripServiceDate
+                        tripsForOriStopByRouteID[routeID].tripRecos[o].tripID ==
+                        tripsForDesStopByRouteID[routeID].tripRecos[d].tripID
+                    ) && (
+                        tripsForOriStopByRouteID[routeID].tripRecos[o].pickupType != 1 &&
+                        tripsForDesStopByRouteID[routeID].tripRecos[d].dropoffType != 1
+                    ) && (
+                        tripsForOriStopByRouteID[routeID].tripRecos[o].tripServiceDate ==
+                        tripsForDesStopByRouteID[routeID].tripRecos[d].tripServiceDate
+                    ) && (
+                        tripsForOriStopByRouteID[routeID].tripRecos[o].tripStatus != SKIP &&
+                        tripsForDesStopByRouteID[routeID].tripRecos[d].tripStatus != SKIP
+                    ) && (
+                        tripsForOriStopByRouteID[routeID].tripRecos[o].tripStatus != CANCEL &&
+                        tripsForDesStopByRouteID[routeID].tripRecos[d].tripStatus != CANCEL
+                    ))
+                {
+                    tripsForBothStopsOri[routeID].tripRecos.push_back(tripsForOriStopByRouteID[routeID].tripRecos[o]);
+                    tripsForBothStopsDes[routeID].tripRecos.push_back(tripsForDesStopByRouteID[routeID].tripRecos[d]);
+                }
+            }
+        }
+    }
+
+    // If this is the first set of recommendations, setup the recommendation vectors
+    for (const QString &routeID : tripsForBothStopsOri.keys()) {
+        // Flatten trips into a single array (as opposed to the nesting by route present) to sorted times together
+        for (const GTFS::StopRecoTripRec &rtorigin : tripsForBothStopsOri[routeID].tripRecos) {
+            GTFS::TripRecStat tripStat = rtorigin.tripStatus;
+            if (tripStat == GTFS::IRRELEVANT ||
+                (_realtimeOnly && (tripStat == GTFS::SCHEDULE || tripStat == GTFS::NOSCHEDULE))) {
+                continue;
+            }
+
+            if (legNum == 0) {
+                QVector<StopRecoTripRec> connection;
+                connection.push_back(rtorigin);
+
+                // Add destination arrival info as second item
+                for (const GTFS::StopRecoTripRec &rtdest : tripsForBothStopsDes[routeID].tripRecos) {
+                    if (rtdest.tripID != rtorigin.tripID) {
+                        // Are we even looking at the same tripId?
+                        continue;
+                    }
+                    if (rtorigin.stopSequenceNum > rtdest.stopSequenceNum) {
+                        // Is the origin preceding the destination in stop-sequence number?
+                        continue;
+                    }
+                    connection.push_back(rtdest);
+                    break;
+                }
+                allRecos.push_back(connection);
+
+                // Sort by arrival time at origin stop
+                std::sort(allRecos.begin(), allRecos.end(),
+                          [](const QVector<StopRecoTripRec> &v1, const QVector<StopRecoTripRec> &v2) {
+                              return v1[0].waitTimeSec < v2[0].waitTimeSec;
+                          });
+            } else {
+                // Subsequent connections for a trip must be connectable by comparing the arrival time of the end of
+                // the previous leg and the departure time of the origin of this leg (plus any buffer time in minutes)
+                for (qsizetype r = 0; r < allRecos.length(); ++r) {
+                    // Check that the trip doesn't have this leg already applied
+                    if (allRecos[r].length() == 2 + legNum * 2) {
+                        continue;
+                    }
+
+                    // Check that the trip isn't "dead" (missing connection)
+                    if (deadRecos.contains(r)) {
+                        continue;
+                    }
+
+                    // Earliest-possible departure time
+                    QDateTime arrivalPreviousDest = allRecos[r].last().realTimeArrival.isNull() ?
+                                                    allRecos[r].last().schArrTime : allRecos[r].last().realTimeArrival;
+
+                    QDateTime earliestDep = arrivalPreviousDest.addSecs(xferMin * 60);
+
+                    // Pick the first "reachable" trip that covers the origin-and-destination
+                    for (const GTFS::StopRecoTripRec &rtdest : tripsForBothStopsDes[routeID].tripRecos) {
+                        if (rtdest.tripID != rtorigin.tripID) {
+                            continue;
+                        }
+                        if (rtorigin.stopSequenceNum > rtdest.stopSequenceNum) {
+                            continue;
+                        }
+                        QDateTime dep = rtorigin.realTimeDeparture.isNull() ?
+                                        rtorigin.schDepTime : rtorigin.realTimeDeparture;
+                        if (dep < earliestDep) {
+                            continue;
+                        }
+                        allRecos[r].push_back(rtorigin);
+                        allRecos[r].push_back(rtdest);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    // Ensure that each trip had a connection added.
+    // If for some reason it could not be added, take the trip out of consideration.
+    for (qsizetype r = 0; r < allRecos.length(); ++r) {
+        if (allRecos[r].length() != 2 + legNum * 2) {
+            deadRecos.insert(r);
+        }
+    }
+}
+
+}  // namespace GTFS

--- a/gtfs_modules/endtoendtrips.h
+++ b/gtfs_modules/endtoendtrips.h
@@ -1,0 +1,98 @@
+/*
+ * GtfsProc_Server
+ * Copyright (C) 2023, Daniel Brook
+ *
+ * This file is part of GtfsProc.
+ *
+ * GtfsProc is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * GtfsProc is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with GtfsProc.
+ * If not, see <https://www.gnu.org/licenses/>.
+ *
+ * See included LICENSE.txt file for full license.
+ */
+
+#ifndef ENDTOENDTRIPS_H
+#define ENDTOENDTRIPS_H
+
+#include "staticstatus.h"
+#include "gtfstrip.h"
+#include "gtfsstatus.h"
+#include "gtfsstops.h"
+#include "gtfsstoptimes.h"
+#include "gtfsroute.h"
+#include "operatingday.h"
+#include "tripstopreconciler.h"
+
+namespace GTFS {
+
+class EndToEndTrips : public StaticStatus
+{
+public:
+    /*
+     * Constructor requires the following arguments:
+     *
+     * futureMinutes    - number of minutes into the future to search for departures from the origin station
+     * realtimeOnly     - only use trips with realtime data to make the journey recommendations
+     * argList          - list of stop ids interspersed with connection times in minutes
+     *
+     * Example argument schema:
+     * [0] "stopIdOrigin"
+     * [1] "stopIdFirstConnection"
+     * [2] "2"                      // Indicates 2 minute buffer between alighting at [1] and boarding at [3]
+     * [3] "stopIdConnectionDep"
+     * [4] "stopIdDestination"
+     */
+    EndToEndTrips(qint32 futureMinutes, bool realtimeOnly, QList<QString> argList);
+
+    /* See GtfsProc_Documentation.html for JSON response format */
+    void fillResponseData(QJsonObject &resp);
+
+private:
+    /*
+     * Takes the upcoming departures from the oriStopId and compares the trip IDs to the arrivals at desStopId. As the
+     * recommendations are built out, invalidated ones (where a connection conforming to the limitations set in the
+     * constructor is/are not possible) are stored in deadRecos. The allRecos vector contains all the valid travel
+     * proposals/recommendations.
+     *
+     * Arguments:
+     * legNum           - 0-indexed leg number of the origin-destination requested
+     * xferMin          - transfer time minutes between previous destination arrival and the current origin departure
+     * oriStopId        - stop ID of the beginning of the leg to board
+     * desStopId        - stop ID of the end of the leg to alight
+     * deadRecos        - vector indexes of allRecos which are not possible to connect within 12 hours
+     * allRecos         - internal data structure for each leg and the origin/destination within each leg
+     */
+    void fillRecoOD(quint8                             legNum,
+                    quint32                            xferMin,
+                    QString                            oriStopId,
+                    QString                            desStopId,
+                    QSet<qsizetype>                   &deadRecos,
+                    QVector<QVector<StopRecoTripRec>> &allRecos);
+
+    qint32         _futureMinutes;
+    bool           _realtimeOnly;
+    QList<QString> _tripCnx;
+
+    bool                  _rtData;
+    QDate                 _systemDate;
+    const Status         *_status;
+    const OperatingDay   *_service;
+    const StopData       *_stops;
+    const ParentStopData *_parentSta;
+    const RouteData      *_routes;
+    const TripData       *_tripDB;
+    const StopTimeData   *_stopTimes;
+
+    const GTFS::RealTimeTripUpdate *_realTimeProc;
+};
+
+}  // namespace GTFS
+
+#endif // ENDTOENDTRIPS_H

--- a/gtfs_modules/gtfs_modules.pri
+++ b/gtfs_modules/gtfs_modules.pri
@@ -8,6 +8,7 @@ DEPENDPATH += $$PWD
 
 HEADERS += \
     $$PWD/availableroutes.h \
+    $$PWD/endtoendtrips.h \
     $$PWD/realtimeproductstatus.h \
     $$PWD/realtimestatus.h \
     $$PWD/realtimetripinformation.h \
@@ -24,6 +25,7 @@ HEADERS += \
 
 SOURCES += \
     $$PWD/availableroutes.cpp \
+    $$PWD/endtoendtrips.cpp \
     $$PWD/realtimeproductstatus.cpp \
     $$PWD/realtimestatus.cpp \
     $$PWD/realtimetripinformation.cpp \

--- a/gtfs_modules/upcomingstopservice.cpp
+++ b/gtfs_modules/upcomingstopservice.cpp
@@ -156,7 +156,7 @@ void UpcomingStopService::fillResponseData(QJsonObject &resp)
                 }
 
                 QJsonObject stopTripItem;
-                fillTripData(rts, stopTripItem);
+                fillTripData(rts, stopTripItem, getStatus()->format12h(), (*_tripDB)[rts.tripID].trip_short_name);
                 stopTrips.push_back(stopTripItem);
 
                 ++tripsFoundForRoute;
@@ -206,7 +206,8 @@ void UpcomingStopService::fillResponseData(QJsonObject &resp)
         for (const QPair<GTFS::StopRecoTripRec, QString> &rts : unifiedTrips) {
             QJsonObject stopTripItem;
             stopTripItem["route_id"] = rts.second;    // Link to the route information
-            fillTripData(rts.first, stopTripItem);
+            fillTripData(rts.first, stopTripItem, getStatus()->format12h(),
+                         (*_tripDB)[rts.first.tripID].trip_short_name);
             stopRouteArray.push_back(stopTripItem);
         }
 
@@ -222,12 +223,14 @@ void UpcomingStopService::fillResponseData(QJsonObject &resp)
     }
 }
 
-void UpcomingStopService::fillTripData(const StopRecoTripRec &rts, QJsonObject &stopTripItem)
+void UpcomingStopService::fillTripData(const StopRecoTripRec &rts, QJsonObject &stopTripItem, bool format12h, QString shortName)
 {
     GTFS::TripRecStat tripStat = rts.tripStatus;
 
     stopTripItem["trip_id"]         = rts.tripID;
-    stopTripItem["short_name"]      = (*_tripDB)[rts.tripID].trip_short_name;
+    stopTripItem["stop_id"]         = rts.stopID;
+    stopTripItem["route_id"]        = rts.routeID;
+    stopTripItem["short_name"]      = shortName;
     stopTripItem["wait_time_sec"]   = rts.waitTimeSec;
     stopTripItem["headsign"]        = rts.headsign;
     stopTripItem["pickup_type"]     = rts.pickupType;
@@ -235,7 +238,7 @@ void UpcomingStopService::fillTripData(const StopRecoTripRec &rts, QJsonObject &
     stopTripItem["trip_begins"]     = rts.beginningOfTrip;
     stopTripItem["trip_terminates"] = rts.endOfTrip;
 
-    if (getStatus()->format12h()) {
+    if (format12h) {
         stopTripItem["dep_time"]        = rts.schDepTime.isNull() ? "-" : rts.schDepTime.toString("ddd h:mma");
         stopTripItem["arr_time"]        = rts.schArrTime.isNull() ? "-" : rts.schArrTime.toString("ddd h:mma");
     } else {
@@ -264,7 +267,7 @@ void UpcomingStopService::fillTripData(const StopRecoTripRec &rts, QJsonObject &
         realTimeData["offset_seconds"] = rts.realTimeOffsetSec;
         realTimeData["vehicle"]        = rts.vehicleRealTime;
 
-        if (getStatus()->format12h()) {
+        if (format12h) {
             realTimeData["actual_arrival"]   = rts.realTimeArrival.toString("ddd h:mma");
             realTimeData["actual_departure"] = rts.realTimeDeparture.toString("ddd h:mma");
         } else {

--- a/gtfs_modules/upcomingstopservice.h
+++ b/gtfs_modules/upcomingstopservice.h
@@ -80,6 +80,9 @@ public:
     /* See GtfsProc_Documentation.html for JSON response format */
     void fillResponseData(QJsonObject &resp);
 
+    // Utility Functions
+    static void fillTripData(const GTFS::StopRecoTripRec &rts, QJsonObject &stopTripItem, bool format12h, QString shortName);
+
 private:
     QList<QString> _stopIDs;
     QDate          _serviceDate;
@@ -97,9 +100,6 @@ private:
 
     bool _rtData;
     const GTFS::RealTimeTripUpdate *_realTimeProc;
-
-    // Utility Functions
-    void fillTripData(const GTFS::StopRecoTripRec &rts, QJsonObject &stopTripItem);
 };
 
 }  // Namespace GTFS

--- a/gtfs_process/tripstopreconciler.cpp
+++ b/gtfs_process/tripstopreconciler.cpp
@@ -262,6 +262,8 @@ void TripStopReconciler::getTripsByRoute(QHash<QString, StopRecoRouteRec> &route
                 tripRecord.tripID          = tripAndIndex.first;
                 tripRecord.vehicleRealTime = rActiveFeed->getOperatingVehicle(tripRecord.tripID);
                 tripRecord.stopID          = stopID;
+                tripRecord.stopSequenceNum = tripAndIndex.second;
+                tripRecord.routeID         = routeID;
 
                 // Calculate wait time and actual departure/arrivals if available
                 QDateTime prArrTime, prDepTime;
@@ -356,6 +358,7 @@ void TripStopReconciler::addTripRecordsForServiceDay(const QString    &routeID,
         // Populate the trip-record with all the pertinent / necessary details
         StopRecoTripRec tripRec;
         tripRec.tripID          = curTripId;
+        tripRec.routeID         = routeID;
         tripRec.stopID          = (*sStopTimes)[curTripId].at(stopTripIdx).stop_id;
         tripRec.stopSequenceNum = (*sStopTimes)[curTripId].at(stopTripIdx).stop_sequence;
         tripRec.beginningOfTrip = (stopTripIdx == 0) ? true : false;

--- a/gtfs_process/tripstopreconciler.h
+++ b/gtfs_process/tripstopreconciler.h
@@ -49,6 +49,7 @@ typedef enum {
  */
 typedef struct {
     QString      tripID;              // Trip ID of the trip serving the stop
+    QString      routeID;             // Route ID of the trip serving the stop
     bool         realTimeDataAvail;   // TRUE if there is real-time data available for this item
     qint64       realTimeOffsetSec;   // Schedule deviation (if a real-time recommendation with a static counterpart)
     TripRecStat  tripStatus;          // * See above *

--- a/gtfs_realtime/gtfs_realtime.pri
+++ b/gtfs_realtime/gtfs_realtime.pri
@@ -32,7 +32,7 @@ SOURCES += \
     $$PWD/gtfsrealtimefeed.cpp
 
 # For Debian/Ubunto Linux:
-#LIBS += -lprotobuf -latomic
+LIBS += -lprotobuf -latomic
 
 # For Arch/Manjaro Linux:
-LIBS += -lprotobuf -latomic -labsl_log_internal_check_op -labsl_log_internal_message -labsl_status
+#LIBS += -lprotobuf -latomic -labsl_log_internal_check_op -labsl_log_internal_message -labsl_status

--- a/gtfs_realtime/gtfs_realtime.pri
+++ b/gtfs_realtime/gtfs_realtime.pri
@@ -19,7 +19,6 @@ protobuf_impl.commands = $$escape_expand(\n)
 protobuf_impl.variable_out = SOURCES
 QMAKE_EXTRA_COMPILERS += protobuf_impl
 
-
 # Wrapper /abstraction objects to avoid coding directly against protobuf files
 INCLUDEPATH += $$PWD
 
@@ -32,4 +31,8 @@ SOURCES += \
     $$PWD/gtfsrealtimegateway.cpp\
     $$PWD/gtfsrealtimefeed.cpp
 
-LIBS += -lprotobuf -latomic
+# For Debian/Ubunto Linux:
+#LIBS += -lprotobuf -latomic
+
+# For Arch/Manjaro Linux:
+LIBS += -lprotobuf -latomic -labsl_log_internal_check_op -labsl_log_internal_message -labsl_status

--- a/gtfs_realtime/gtfsrealtimefeed.cpp
+++ b/gtfs_realtime/gtfsrealtimefeed.cpp
@@ -345,7 +345,7 @@ void RealTimeTripUpdate::tripStopActualTime(const QString              &tripID,
         // (for quality assurance, these kinds of trips will still be considered mimatches as they violate spec)
         QString stopIdRT = QString::fromStdString(tri.stop_time_update(rtSTUpd).stop_id());
         if (tri.stop_time_update(rtSTUpd).has_stop_sequence() &&
-            stopSeq == tri.stop_time_update(rtSTUpd).stop_sequence()) {
+            stopSeq == tri.stop_time_update(rtSTUpd).stop_sequence() && stopIdRT == stop_id) {
             // Match Stop ID and Stop Sequence when both are provided
             break;
         } else if ((!tri.stop_time_update(rtSTUpd).has_stop_sequence() || _loosenStopSeqEnf) && stop_id == stopIdRT) {
@@ -473,7 +473,8 @@ void RealTimeTripUpdate::fillStopTimesForTrip(rtUpdateMatch               realTi
                 // (should also enforce that the stop id matches the trip update contents)
                 QString stopIdRT = QString::fromStdString(tri.stop_time_update(stUpdIdx).stop_id());
                 if (tri.stop_time_update(stUpdIdx).has_stop_sequence() &&
-                    static_cast<quint32>(stopRec.stop_sequence) == tri.stop_time_update(stUpdIdx).stop_sequence()) {
+                    static_cast<quint32>(stopRec.stop_sequence) == tri.stop_time_update(stUpdIdx).stop_sequence() &&
+                    stopRec.stop_id == stopIdRT) {
                     stu.stopSequence = stopRec.stop_sequence;
                     break;
                 } else if ((!tri.stop_time_update(stUpdIdx).has_stop_sequence() || _loosenStopSeqEnf) &&

--- a/gtfsproc/gtfsrequestprocessor.cpp
+++ b/gtfsproc/gtfsrequestprocessor.cpp
@@ -23,6 +23,7 @@
 // GTFS logical modules
 #include "staticstatus.h"
 #include "availableroutes.h"
+#include "endtoendtrips.h"
 #include "tripscheduledisplay.h"
 #include "tripsservingroute.h"
 #include "tripsservingstop.h"
@@ -160,6 +161,17 @@ void GtfsRequestProcessor::run()
                 GTFS::ServiceBetweenStops SBS(decodedStopIDs.at(0), decodedStopIDs.at(1), reqDate);
                 SBS.fillResponseData(respJson);
             }
+        } else if (! userApp.compare("EES", Qt::CaseInsensitive) || ! userApp.compare("EER", Qt::CaseInsensitive)) {
+            bool realtimeOnly = false;
+            if (! userApp.compare("EER", Qt::CaseInsensitive)) {
+                realtimeOnly = true;
+            }
+            QList<QString> args;
+            QString remainingReq;
+            qint32 futureMinutes = determineMinuteRange(userReq, remainingReq);
+            listifyIDs(remainingReq, args);
+            GTFS::EndToEndTrips E2E(futureMinutes, realtimeOnly, args);
+            E2E.fillResponseData(respJson);
         } else if (! userApp.compare("DRT", Qt::CaseInsensitive)) {
             GTFS::RealtimeTripInformation DRT;
             DRT.dumpRealTime(SystemResponse);

--- a/gtfsproc/server_main.cpp
+++ b/gtfsproc/server_main.cpp
@@ -33,7 +33,7 @@ int main(int argc, char *argv[])
      */
     QCoreApplication a(argc, argv);
     QCoreApplication::setApplicationName("GtfsProc");
-    QCoreApplication::setApplicationVersion("2.1.1");
+    QCoreApplication::setApplicationVersion("2.2.0");
 
     QTextStream console(stdout);
     QString appName = QCoreApplication::applicationName();


### PR DESCRIPTION
Upgrades to 2.2.0:

See changes to ReleaseNotes.txt

Summary:
- Added stop and route information to NEX/NCF so payload of EES/EER can reuse the schema of those
- When doing strict stop sequence matching, also enforce the stop id is the same, else the loosen enforcement option (-q) does not get picked properly